### PR TITLE
[FEAT] 타임 블록 생성

### DIFF
--- a/src/main/java/com/tiki/server/common/entity/Position.java
+++ b/src/main/java/com/tiki/server/common/entity/Position.java
@@ -1,5 +1,14 @@
 package com.tiki.server.common.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum Position {
-	ADMIN, EXECUTIVE, MEMBER,
+	ADMIN(1), EXECUTIVE(2), MEMBER(3);
+
+	private final int authorization;
+
+	Position(int authorization) {
+		this.authorization = authorization;
+	}
 }

--- a/src/main/java/com/tiki/server/common/support/UriGenerator.java
+++ b/src/main/java/com/tiki/server/common/support/UriGenerator.java
@@ -1,0 +1,26 @@
+package com.tiki.server.common.support;
+
+import java.net.URI;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+@Component
+public class UriGenerator {
+
+	public static URI getUri(String path, long id) {
+		return ServletUriComponentsBuilder
+			.fromCurrentRequest()
+			.path(path + id)
+			.buildAndExpand()
+			.toUri();
+	}
+
+	public static URI getUri(String path) {
+		return ServletUriComponentsBuilder
+			.fromCurrentRequest()
+			.path(path)
+			.buildAndExpand()
+			.toUri();
+	}
+}

--- a/src/main/java/com/tiki/server/document/adapter/DocumentCreator.java
+++ b/src/main/java/com/tiki/server/document/adapter/DocumentCreator.java
@@ -1,0 +1,18 @@
+package com.tiki.server.document.adapter;
+
+import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.document.entity.Document;
+import com.tiki.server.document.repository.DocumentRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RepositoryAdapter
+@RequiredArgsConstructor
+public class DocumentCreator {
+
+	private final DocumentRepository documentRepository;
+
+	public Document create(Document document) {
+		return documentRepository.save(document);
+	}
+}

--- a/src/main/java/com/tiki/server/document/adapter/DocumentSaver.java
+++ b/src/main/java/com/tiki/server/document/adapter/DocumentSaver.java
@@ -8,11 +8,11 @@ import lombok.RequiredArgsConstructor;
 
 @RepositoryAdapter
 @RequiredArgsConstructor
-public class DocumentCreator {
+public class DocumentSaver {
 
 	private final DocumentRepository documentRepository;
 
-	public Document create(Document document) {
+	public Document save(Document document) {
 		return documentRepository.save(document);
 	}
 }

--- a/src/main/java/com/tiki/server/document/adapter/DocumentSaver.java
+++ b/src/main/java/com/tiki/server/document/adapter/DocumentSaver.java
@@ -12,7 +12,7 @@ public class DocumentSaver {
 
 	private final DocumentRepository documentRepository;
 
-	public Document save(Document document) {
-		return documentRepository.save(document);
+	public void save(Document document) {
+		documentRepository.save(document);
 	}
 }

--- a/src/main/java/com/tiki/server/document/entity/DeletedDocument.java
+++ b/src/main/java/com/tiki/server/document/entity/DeletedDocument.java
@@ -22,6 +22,8 @@ public class DeletedDocument {
 	@Column(name = "deleted_document_id")
 	private Long id;
 
+	private String fileName;
+
 	private String fileUrl;
 
 	@Column(name = "block_id")
@@ -30,8 +32,9 @@ public class DeletedDocument {
 	private LocalDate deletedDate;
 
 	@Builder
-	public static DeletedDocument of(String fileUrl, long timeBlockId, LocalDate deletedDate) {
+	public static DeletedDocument of(String fileName, String fileUrl, long timeBlockId, LocalDate deletedDate) {
 		return DeletedDocument.builder()
+			.fileName(fileName)
 			.fileUrl(fileUrl)
 			.timeBlockId(timeBlockId)
 			.deletedDate(deletedDate)

--- a/src/main/java/com/tiki/server/document/entity/DeletedDocument.java
+++ b/src/main/java/com/tiki/server/document/entity/DeletedDocument.java
@@ -1,0 +1,40 @@
+package com.tiki.server.document.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class DeletedDocument {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "deleted_document_id")
+	private Long id;
+
+	private String fileUrl;
+
+	@Column(name = "block_id")
+	private long timeBlockId;
+
+	private LocalDate deletedDate;
+
+	@Builder
+	public static DeletedDocument of(String fileUrl, long timeBlockId, LocalDate deletedDate) {
+		return DeletedDocument.builder()
+			.fileUrl(fileUrl)
+			.timeBlockId(timeBlockId)
+			.deletedDate(deletedDate)
+			.build();
+	}
+}

--- a/src/main/java/com/tiki/server/document/entity/Document.java
+++ b/src/main/java/com/tiki/server/document/entity/Document.java
@@ -1,5 +1,6 @@
 package com.tiki.server.document.entity;
 
+import static com.tiki.server.document.entity.DocumentStatus.BASIC;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -17,6 +18,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,4 +42,11 @@ public class Document extends BaseTime {
 	private DocumentStatus status;
 
 	private LocalDate deletedDate;
+
+	@Builder
+	public Document(String fileUrl, TimeBlock timeBlock) {
+		this.fileUrl = fileUrl;
+		this.timeBlock = timeBlock;
+		this.status = BASIC;
+	}
 }

--- a/src/main/java/com/tiki/server/document/entity/Document.java
+++ b/src/main/java/com/tiki/server/document/entity/Document.java
@@ -1,19 +1,13 @@
 package com.tiki.server.document.entity;
 
-import static com.tiki.server.document.entity.DocumentStatus.BASIC;
-import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import com.tiki.server.common.entity.BaseTime;
 import com.tiki.server.timeblock.entity.TimeBlock;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -38,15 +32,11 @@ public class Document extends BaseTime {
 	@JoinColumn(name = "block_id")
 	private TimeBlock timeBlock;
 
-	@Enumerated(value = STRING)
-	private DocumentStatus status;
-
-	private LocalDate deletedDate;
-
 	@Builder
-	public Document(String fileUrl, TimeBlock timeBlock) {
-		this.fileUrl = fileUrl;
-		this.timeBlock = timeBlock;
-		this.status = BASIC;
+	public static Document of(String fileUrl, TimeBlock timeBlock) {
+		return Document.builder()
+			.fileUrl(fileUrl)
+			.timeBlock(timeBlock)
+			.build();
 	}
 }

--- a/src/main/java/com/tiki/server/document/entity/Document.java
+++ b/src/main/java/com/tiki/server/document/entity/Document.java
@@ -26,6 +26,8 @@ public class Document extends BaseTime {
 	@Column(name = "document_id")
 	private Long id;
 
+	private String fileName;
+
 	private String fileUrl;
 
 	@ManyToOne(fetch = LAZY)
@@ -33,8 +35,9 @@ public class Document extends BaseTime {
 	private TimeBlock timeBlock;
 
 	@Builder
-	public static Document of(String fileUrl, TimeBlock timeBlock) {
+	public static Document of(String fileName, String fileUrl, TimeBlock timeBlock) {
 		return Document.builder()
+			.fileName(fileName)
 			.fileUrl(fileUrl)
 			.timeBlock(timeBlock)
 			.build();

--- a/src/main/java/com/tiki/server/document/entity/Document.java
+++ b/src/main/java/com/tiki/server/document/entity/Document.java
@@ -2,6 +2,8 @@ package com.tiki.server.document.entity;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
 
 import com.tiki.server.common.entity.BaseTime;
 import com.tiki.server.timeblock.entity.TimeBlock;
@@ -12,13 +14,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@Builder(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
 public class Document extends BaseTime {
 
 	@Id
@@ -34,7 +39,6 @@ public class Document extends BaseTime {
 	@JoinColumn(name = "block_id")
 	private TimeBlock timeBlock;
 
-	@Builder
 	public static Document of(String fileName, String fileUrl, TimeBlock timeBlock) {
 		return Document.builder()
 			.fileName(fileName)

--- a/src/main/java/com/tiki/server/document/entity/DocumentStatus.java
+++ b/src/main/java/com/tiki/server/document/entity/DocumentStatus.java
@@ -1,5 +1,0 @@
-package com.tiki.server.document.entity;
-
-public enum DocumentStatus {
-	BASIC, DELETED
-}

--- a/src/main/java/com/tiki/server/external/constant/ExternalConstant.java
+++ b/src/main/java/com/tiki/server/external/constant/ExternalConstant.java
@@ -1,0 +1,7 @@
+package com.tiki.server.external.constant;
+
+public class ExternalConstant {
+
+	public static final Long PRE_SIGNED_URL_EXPIRE_MINUTE = 10L;
+	public static final String FILE_SAVE_PREFIX = "file/";
+}

--- a/src/main/java/com/tiki/server/external/controller/S3Controller.java
+++ b/src/main/java/com/tiki/server/external/controller/S3Controller.java
@@ -5,6 +5,7 @@ import static com.tiki.server.external.message.SuccessMessage.PRESIGNED_URL_GET_
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,7 +25,7 @@ public class S3Controller {
 	private final S3Service s3Service;
 
 	@GetMapping("/upload")
-	public ResponseEntity<SuccessResponse<PreSignedUrlResponse>> getPreSignedUrl(PreSignedUrlRequest request) {
+	public ResponseEntity<SuccessResponse<PreSignedUrlResponse>> getPreSignedUrl(@RequestBody PreSignedUrlRequest request) {
 		val response = s3Service.getUploadPreSignedUrl(request);
 		return ResponseEntity.ok(success(PRESIGNED_URL_GET_SUCCESS.getMessage(), response));
 	}

--- a/src/main/java/com/tiki/server/external/controller/S3Controller.java
+++ b/src/main/java/com/tiki/server/external/controller/S3Controller.java
@@ -1,0 +1,31 @@
+package com.tiki.server.external.controller;
+
+import static com.tiki.server.common.dto.SuccessResponse.*;
+import static com.tiki.server.external.message.SuccessMessage.PRESIGNED_URL_GET_SUCCESS;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tiki.server.common.dto.SuccessResponse;
+import com.tiki.server.external.dto.request.PreSignedUrlRequest;
+import com.tiki.server.external.dto.response.PreSignedUrlResponse;
+import com.tiki.server.external.util.S3Service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.val;
+
+@RestController
+@RequestMapping("api/v1/file")
+@RequiredArgsConstructor
+public class S3Controller {
+
+	private final S3Service s3Service;
+
+	@GetMapping("/upload")
+	public ResponseEntity<SuccessResponse<PreSignedUrlResponse>> getPreSignedUrl(PreSignedUrlRequest request) {
+		val response = s3Service.getUploadPreSignedUrl(request);
+		return ResponseEntity.ok(success(PRESIGNED_URL_GET_SUCCESS.getMessage(), response));
+	}
+}

--- a/src/main/java/com/tiki/server/external/dto/request/PreSignedUrlRequest.java
+++ b/src/main/java/com/tiki/server/external/dto/request/PreSignedUrlRequest.java
@@ -1,0 +1,8 @@
+package com.tiki.server.external.dto.request;
+
+import lombok.NonNull;
+
+public record PreSignedUrlRequest(
+	@NonNull String fileFormat
+) {
+}

--- a/src/main/java/com/tiki/server/external/dto/response/PreSignedUrlResponse.java
+++ b/src/main/java/com/tiki/server/external/dto/response/PreSignedUrlResponse.java
@@ -1,0 +1,19 @@
+package com.tiki.server.external.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.Builder;
+
+@Builder(access = PRIVATE)
+public record PreSignedUrlResponse(
+	String fileName,
+	String url
+) {
+
+	public static PreSignedUrlResponse of(String fileName, String url) {
+		return PreSignedUrlResponse.builder()
+			.fileName(fileName)
+			.url(url)
+			.build();
+	}
+}

--- a/src/main/java/com/tiki/server/external/dto/response/PreSignedUrlResponse.java
+++ b/src/main/java/com/tiki/server/external/dto/response/PreSignedUrlResponse.java
@@ -3,11 +3,12 @@ package com.tiki.server.external.dto.response;
 import static lombok.AccessLevel.PRIVATE;
 
 import lombok.Builder;
+import lombok.NonNull;
 
 @Builder(access = PRIVATE)
 public record PreSignedUrlResponse(
-	String fileName,
-	String url
+	@NonNull String fileName,
+	@NonNull String url
 ) {
 
 	public static PreSignedUrlResponse of(String fileName, String url) {

--- a/src/main/java/com/tiki/server/external/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/external/message/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.tiki.server.external.message;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 
 import org.springframework.http.HttpStatus;
 
@@ -11,8 +12,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-	/* 400 BAD_REQUEST : 잘못된 요청 */
-	INVALID_FILE_SIZE(BAD_REQUEST, "파일의 용량은 30MB를 초과할 수 없습니다.");
+	/* 500 INTERNAL_SERVER_ERROR : 서버 에러 */
+	PRESIGNED_URL_GET_ERROR(INTERNAL_SERVER_ERROR, "S3 PRESIGNED URL 불러오기 실패"),
+	FILE_DELETE_ERROR(INTERNAL_SERVER_ERROR, "S3 버킷의 파일 삭제 실패");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/tiki/server/external/message/SuccessMessage.java
+++ b/src/main/java/com/tiki/server/external/message/SuccessMessage.java
@@ -1,0 +1,13 @@
+package com.tiki.server.external.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessMessage {
+
+	PRESIGNED_URL_GET_SUCCESS("S3 PRESIGNED URL 불러오기 성공");
+
+	private final String message;
+}

--- a/src/main/java/com/tiki/server/member/adapter/MemberFinder.java
+++ b/src/main/java/com/tiki/server/member/adapter/MemberFinder.java
@@ -1,7 +1,14 @@
 package com.tiki.server.member.adapter;
 
+import static com.tiki.server.member.message.ErrorCode.INVALID_MEMBER;
+import static com.tiki.server.team.message.ErrorCode.INVALID_TEAM;
+
 import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.member.entity.Member;
+import com.tiki.server.member.exception.MemberException;
 import com.tiki.server.member.repository.MemberRepository;
+import com.tiki.server.team.entity.Team;
+import com.tiki.server.team.exception.TeamException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -10,4 +17,9 @@ import lombok.RequiredArgsConstructor;
 public class MemberFinder {
 
 	private final MemberRepository memberRepository;
+
+	public Member findById(long memberId) {
+		return memberRepository.findById(memberId)
+			.orElseThrow(() -> new MemberException(INVALID_MEMBER));
+	}
 }

--- a/src/main/java/com/tiki/server/memberteammanager/adapter/MemberTeamManagerFinder.java
+++ b/src/main/java/com/tiki/server/memberteammanager/adapter/MemberTeamManagerFinder.java
@@ -1,6 +1,10 @@
 package com.tiki.server.memberteammanager.adapter;
 
+import static com.tiki.server.memberteammanager.message.ErrorCode.TEMP;
+
 import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.memberteammanager.entity.MemberTeamManager;
+import com.tiki.server.memberteammanager.exception.MemberTeamManagerException;
 import com.tiki.server.memberteammanager.repository.MemberTeamManagerRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -10,4 +14,9 @@ import lombok.RequiredArgsConstructor;
 public class MemberTeamManagerFinder {
 
 	private final MemberTeamManagerRepository teamManagerRepository;
+
+	public MemberTeamManager findByMemberIdAndTeamId(long memberId, long teamId) {
+		return teamManagerRepository.findByMemberIdAndTeamId(memberId, teamId)
+			.orElseThrow(() -> new MemberTeamManagerException(TEMP));
+	}
 }

--- a/src/main/java/com/tiki/server/memberteammanager/adapter/MemberTeamManagerFinder.java
+++ b/src/main/java/com/tiki/server/memberteammanager/adapter/MemberTeamManagerFinder.java
@@ -1,6 +1,6 @@
 package com.tiki.server.memberteammanager.adapter;
 
-import static com.tiki.server.memberteammanager.message.ErrorCode.TEMP;
+import static com.tiki.server.memberteammanager.message.ErrorCode.INVALID_MEMBER_TEAM_MANAGER;
 
 import com.tiki.server.common.support.RepositoryAdapter;
 import com.tiki.server.memberteammanager.entity.MemberTeamManager;
@@ -17,6 +17,6 @@ public class MemberTeamManagerFinder {
 
 	public MemberTeamManager findByMemberIdAndTeamId(long memberId, long teamId) {
 		return teamManagerRepository.findByMemberIdAndTeamId(memberId, teamId)
-			.orElseThrow(() -> new MemberTeamManagerException(TEMP));
+			.orElseThrow(() -> new MemberTeamManagerException(INVALID_MEMBER_TEAM_MANAGER));
 	}
 }

--- a/src/main/java/com/tiki/server/memberteammanager/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/memberteammanager/message/ErrorCode.java
@@ -12,7 +12,7 @@ import lombok.Getter;
 public enum ErrorCode {
 
 	/* 404 NOT_FOUND : 자원을 찾을 수 없음 */
-	TEMP(NOT_FOUND, "컴파일 에러 방지용 에러입니다.");
+	INVALID_MEMBER_TEAM_MANAGER(NOT_FOUND, "팀에 존재하지 않는 회원입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/tiki/server/memberteammanager/repository/MemberTeamManagerRepository.java
+++ b/src/main/java/com/tiki/server/memberteammanager/repository/MemberTeamManagerRepository.java
@@ -1,8 +1,11 @@
 package com.tiki.server.memberteammanager.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.tiki.server.memberteammanager.entity.MemberTeamManager;
 
 public interface MemberTeamManagerRepository extends JpaRepository<MemberTeamManager, Long> {
+	Optional<MemberTeamManager> findByMemberIdAndTeamId(Long memberId, Long teamId);
 }

--- a/src/main/java/com/tiki/server/team/adapter/TeamFinder.java
+++ b/src/main/java/com/tiki/server/team/adapter/TeamFinder.java
@@ -1,6 +1,10 @@
 package com.tiki.server.team.adapter;
 
+import static com.tiki.server.team.message.ErrorCode.INVALID_TEAM;
+
 import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.team.entity.Team;
+import com.tiki.server.team.exception.TeamException;
 import com.tiki.server.team.repository.TeamRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -10,4 +14,9 @@ import lombok.RequiredArgsConstructor;
 public class TeamFinder {
 
 	private final TeamRepository teamRepository;
+
+	public Team findById(long teamId) {
+		return teamRepository.findById(teamId)
+			.orElseThrow(() -> new TeamException(INVALID_TEAM));
+	}
 }

--- a/src/main/java/com/tiki/server/team/controller/TeamController.java
+++ b/src/main/java/com/tiki/server/team/controller/TeamController.java
@@ -1,7 +1,5 @@
 package com.tiki.server.team.controller;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/tiki/server/team/entity/Group.java
+++ b/src/main/java/com/tiki/server/team/entity/Group.java
@@ -1,5 +1,5 @@
 package com.tiki.server.team.entity;
 
-public enum TeamType {
+public enum Group {
 	ALLIANCE, UNIVERSITY
 }

--- a/src/main/java/com/tiki/server/team/entity/Team.java
+++ b/src/main/java/com/tiki/server/team/entity/Team.java
@@ -31,7 +31,7 @@ public class Team extends BaseTime {
 	private Category category;
 
 	@Enumerated(value = STRING)
-	private TeamType teamType;
+	private Group group;
 
 	private String imageUrl;
 

--- a/src/main/java/com/tiki/server/timeblock/adapter/TimeBlockCreator.java
+++ b/src/main/java/com/tiki/server/timeblock/adapter/TimeBlockCreator.java
@@ -1,0 +1,18 @@
+package com.tiki.server.timeblock.adapter;
+
+import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.timeblock.entity.TimeBlock;
+import com.tiki.server.timeblock.repository.TimeBlockRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RepositoryAdapter
+@RequiredArgsConstructor
+public class TimeBlockCreator {
+
+	private final TimeBlockRepository timeBlockRepository;
+
+	public TimeBlock createTimeBlock(TimeBlock timeBlock) {
+		return timeBlockRepository.save(timeBlock);
+	}
+}

--- a/src/main/java/com/tiki/server/timeblock/adapter/TimeBlockSaver.java
+++ b/src/main/java/com/tiki/server/timeblock/adapter/TimeBlockSaver.java
@@ -8,11 +8,11 @@ import lombok.RequiredArgsConstructor;
 
 @RepositoryAdapter
 @RequiredArgsConstructor
-public class TimeBlockCreator {
+public class TimeBlockSaver {
 
 	private final TimeBlockRepository timeBlockRepository;
 
-	public TimeBlock createTimeBlock(TimeBlock timeBlock) {
+	public TimeBlock save(TimeBlock timeBlock) {
 		return timeBlockRepository.save(timeBlock);
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/constant/TimeBlockConstant.java
+++ b/src/main/java/com/tiki/server/timeblock/constant/TimeBlockConstant.java
@@ -1,0 +1,7 @@
+package com.tiki.server.timeblock.constant;
+
+public class TimeBlockConstant {
+
+	public static final String EXECUTIVE = "executive";
+	public static final String MEMBER = "member";
+}

--- a/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
+++ b/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
@@ -1,5 +1,8 @@
 package com.tiki.server.timeblock.controller;
 
+import static com.tiki.server.common.dto.SuccessResponse.*;
+import static com.tiki.server.timeblock.message.SuccessMessage.SUCCESS_CREATE_TIME_BLOCK;
+
 import java.security.Principal;
 
 import org.springframework.http.ResponseEntity;
@@ -10,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tiki.server.common.dto.SuccessResponse;
 import com.tiki.server.common.support.UriGenerator;
 import com.tiki.server.timeblock.dto.request.TimeBlockCreationRequest;
 import com.tiki.server.timeblock.dto.response.TimeBlockCreationResponse;
@@ -26,16 +30,16 @@ public class TimeBlockController {
 	private final TimeBlockService timeBlockService;
 
 	@PostMapping("/team/{teamId}/time-block")
-	public ResponseEntity<TimeBlockCreationResponse> createTimeBlock(
+	public ResponseEntity<SuccessResponse<TimeBlockCreationResponse>> createTimeBlock(
 		Principal principal,
 		@PathVariable("teamId") long teamId,
 		@RequestParam String type,
 		@RequestBody TimeBlockCreationRequest request
 	) {
-		val memberId = Long.valueOf(principal.getName());
+		val memberId = Long.parseLong(principal.getName());
 		val response = timeBlockService.createTimeBlock(memberId, teamId, type, request);
 		return ResponseEntity.created(
-			UriGenerator.getUri("/api/v1/time-blocks/team/{teamId}/time-block", response.timeBlockId())
-		);
+			UriGenerator.getUri("/api/v1/time-blocks/team/" + teamId + "/time-block")
+		).body(success(SUCCESS_CREATE_TIME_BLOCK.getMessage(), response));
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
+++ b/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
@@ -1,11 +1,20 @@
 package com.tiki.server.timeblock.controller;
 
+import java.security.Principal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tiki.server.timeblock.dto.response.TimeBlockCreationResponse;
 import com.tiki.server.timeblock.service.TimeBlockService;
 
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,4 +22,16 @@ import lombok.RequiredArgsConstructor;
 public class TimeBlockController {
 
 	private final TimeBlockService timeBlockService;
+
+	@PostMapping("/team/{teamId}/time-block")
+	public ResponseEntity<TimeBlockCreationResponse> createTimeBlock(
+		Principal principal,
+		@PathVariable("teamId") long teamId,
+		@RequestParam String type,
+		@RequestBody
+	) {
+		val memberId = Long.valueOf(principal.getName());
+		val response = timeBlockService.createTimeBlock()
+		return ResponseEntity.created(URI);
+	}
 }

--- a/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
+++ b/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tiki.server.common.support.UriGenerator;
+import com.tiki.server.timeblock.dto.request.TimeBlockCreationRequest;
 import com.tiki.server.timeblock.dto.response.TimeBlockCreationResponse;
 import com.tiki.server.timeblock.service.TimeBlockService;
 
@@ -28,10 +30,12 @@ public class TimeBlockController {
 		Principal principal,
 		@PathVariable("teamId") long teamId,
 		@RequestParam String type,
-		@RequestBody
+		@RequestBody TimeBlockCreationRequest request
 	) {
 		val memberId = Long.valueOf(principal.getName());
-		val response = timeBlockService.createTimeBlock()
-		return ResponseEntity.created(URI);
+		val response = timeBlockService.createTimeBlock(memberId, teamId, type, request);
+		return ResponseEntity.created(
+			UriGenerator.getUri("/api/v1/time-blocks/team/{teamId}/time-block", response.timeBlockId())
+		);
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/dto/request/TimeBlockCreationRequest.java
+++ b/src/main/java/com/tiki/server/timeblock/dto/request/TimeBlockCreationRequest.java
@@ -1,0 +1,4 @@
+package com.tiki.server.timeblock.dto.request;
+
+public record TimeBlockCreationRequest() {
+}

--- a/src/main/java/com/tiki/server/timeblock/dto/request/TimeBlockCreationRequest.java
+++ b/src/main/java/com/tiki/server/timeblock/dto/request/TimeBlockCreationRequest.java
@@ -1,7 +1,7 @@
 package com.tiki.server.timeblock.dto.request;
 
 import java.time.LocalDate;
-import java.util.List;
+import java.util.Map;
 
 import lombok.NonNull;
 
@@ -10,6 +10,6 @@ public record TimeBlockCreationRequest(
 	@NonNull String color,
 	@NonNull LocalDate startDate,
 	@NonNull LocalDate endDate,
-	List<String> filesUrl
+	Map<String, String> files
 ) {
 }

--- a/src/main/java/com/tiki/server/timeblock/dto/request/TimeBlockCreationRequest.java
+++ b/src/main/java/com/tiki/server/timeblock/dto/request/TimeBlockCreationRequest.java
@@ -1,4 +1,15 @@
 package com.tiki.server.timeblock.dto.request;
 
-public record TimeBlockCreationRequest() {
+import java.time.LocalDate;
+import java.util.List;
+
+import lombok.NonNull;
+
+public record TimeBlockCreationRequest(
+	@NonNull String name,
+	@NonNull String color,
+	@NonNull LocalDate startDate,
+	@NonNull LocalDate endDate,
+	List<String> filesUrl
+) {
 }

--- a/src/main/java/com/tiki/server/timeblock/dto/response/TimeBlockCreationResponse.java
+++ b/src/main/java/com/tiki/server/timeblock/dto/response/TimeBlockCreationResponse.java
@@ -1,0 +1,4 @@
+package com.tiki.server.timeblock.dto.response;
+
+public record TimeBlockCreationResponse() {
+}

--- a/src/main/java/com/tiki/server/timeblock/dto/response/TimeBlockCreationResponse.java
+++ b/src/main/java/com/tiki/server/timeblock/dto/response/TimeBlockCreationResponse.java
@@ -1,4 +1,17 @@
 package com.tiki.server.timeblock.dto.response;
 
-public record TimeBlockCreationResponse() {
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.Builder;
+
+@Builder(access = PRIVATE)
+public record TimeBlockCreationResponse(
+	long timeBlockId
+) {
+
+	public static TimeBlockCreationResponse of(long timeBlockId) {
+		return TimeBlockCreationResponse.builder()
+			.timeBlockId(timeBlockId)
+			.build();
+	}
 }

--- a/src/main/java/com/tiki/server/timeblock/entity/TimeBlock.java
+++ b/src/main/java/com/tiki/server/timeblock/entity/TimeBlock.java
@@ -3,12 +3,15 @@ package com.tiki.server.timeblock.entity;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PRIVATE;
+import static lombok.AccessLevel.PROTECTED;
 
 import java.time.LocalDate;
 
 import com.tiki.server.common.entity.BaseTime;
 import com.tiki.server.common.entity.Position;
 import com.tiki.server.team.entity.Team;
+import com.tiki.server.timeblock.dto.request.TimeBlockCreationRequest;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,13 +20,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@Builder(access = PRIVATE)
+@AllArgsConstructor(access = PRIVATE)
+@NoArgsConstructor(access = PROTECTED)
 public class TimeBlock extends BaseTime {
 
 	@Id
@@ -46,21 +52,13 @@ public class TimeBlock extends BaseTime {
 	@JoinColumn(name = "team_id")
 	private Team team;
 
-	@Builder
-	public static TimeBlock of(
-		String name,
-		String color,
-		Position accessiblePosition,
-		LocalDate startDate,
-		LocalDate endDate,
-		Team team
-	) {
+	public static TimeBlock of(Team team, Position accessiblePosition, TimeBlockCreationRequest request) {
 		return TimeBlock.builder()
-			.name(name)
-			.color(color)
+			.name(request.name())
+			.color(request.color())
 			.accessiblePosition(accessiblePosition)
-			.startDate(startDate)
-			.endDate(endDate)
+			.startDate(request.startDate())
+			.endDate(request.endDate())
 			.team(team)
 			.build();
 	}

--- a/src/main/java/com/tiki/server/timeblock/entity/TimeBlock.java
+++ b/src/main/java/com/tiki/server/timeblock/entity/TimeBlock.java
@@ -47,7 +47,7 @@ public class TimeBlock extends BaseTime {
 	private Team team;
 
 	@Builder
-	public TimeBlock(
+	public static TimeBlock of(
 		String name,
 		String color,
 		Position accessiblePosition,
@@ -55,11 +55,13 @@ public class TimeBlock extends BaseTime {
 		LocalDate endDate,
 		Team team
 	) {
-		this.name = name;
-		this.color = color;
-		this.accessiblePosition = accessiblePosition;
-		this.startDate = startDate;
-		this.endDate = endDate;
-		this.team = team;
+		return TimeBlock.builder()
+			.name(name)
+			.color(color)
+			.accessiblePosition(accessiblePosition)
+			.startDate(startDate)
+			.endDate(endDate)
+			.team(team)
+			.build();
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/entity/TimeBlock.java
+++ b/src/main/java/com/tiki/server/timeblock/entity/TimeBlock.java
@@ -17,6 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -30,13 +31,9 @@ public class TimeBlock extends BaseTime {
 	@Column(name = "block_id")
 	private Long id;
 
-	@ManyToOne(fetch = LAZY)
-	@JoinColumn(name = "team_id")
-	private Team team;
+	private String name;
 
 	private String color;
-
-	private String name;
 
 	@Enumerated(value = STRING)
 	private Position accessiblePosition;
@@ -44,4 +41,25 @@ public class TimeBlock extends BaseTime {
 	private LocalDate startDate;
 
 	private LocalDate endDate;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "team_id")
+	private Team team;
+
+	@Builder
+	public TimeBlock(
+		String name,
+		String color,
+		Position accessiblePosition,
+		LocalDate startDate,
+		LocalDate endDate,
+		Team team
+	) {
+		this.name = name;
+		this.color = color;
+		this.accessiblePosition = accessiblePosition;
+		this.startDate = startDate;
+		this.endDate = endDate;
+		this.team = team;
+	}
 }

--- a/src/main/java/com/tiki/server/timeblock/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/timeblock/message/ErrorCode.java
@@ -1,6 +1,7 @@
 package com.tiki.server.timeblock.message;
 
-import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 
 import org.springframework.http.HttpStatus;
 
@@ -11,8 +12,11 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-	/* 404 NOT_FOUND : 자원을 찾을 수 없음 */
-	TEMP(NOT_FOUND, "컴파일 에러 방지용 에러입니다.");
+	/* 400 BAD_REQUEST : 잘못된 요청 */
+	INVALID_TYPE(BAD_REQUEST, "유효한 타입이 아닙니다."),
+
+	/* 403 FORBIDDEN : 권한 없음 */
+	INVALID_AUTHORIZATION(FORBIDDEN, "타임블록에 대한 권한이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/tiki/server/timeblock/message/SuccessMessage.java
+++ b/src/main/java/com/tiki/server/timeblock/message/SuccessMessage.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SuccessMessage {
 
-	TEMP("컴파일 에러 방지용");
+	SUCCESS_CREATE_TIME_BLOCK("타임 블록 생성 성공");
 
 	private final String message;
 }

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -3,10 +3,35 @@ package com.tiki.server.timeblock.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.tiki.server.member.adapter.MemberFinder;
+import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
+import com.tiki.server.team.adapter.TeamFinder;
+import com.tiki.server.timeblock.dto.request.TimeBlockCreationRequest;
+import com.tiki.server.timeblock.dto.response.TimeBlockCreationResponse;
+
 import lombok.RequiredArgsConstructor;
+import lombok.val;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class TimeBlockService {
+
+	private final MemberFinder memberFinder;
+	private final TeamFinder teamFinder;
+	private final MemberTeamManagerFinder memberTeamManagerFinder;
+
+	public TimeBlockCreationResponse createTimeBlock(long memberId, long teamId, String type, TimeBlockCreationRequest request) {
+		val member = memberFinder.findById(memberId);
+		val team = teamFinder.findById(teamId);
+		val position = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId).getPosition();
+	}
+
+	private TimeBlockCreationResponse createExecutiveTimeBlock() {
+
+	}
+
+	private TimeBlockCreationResponse createMemberTimeBlock() {
+
+	}
 }

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -71,14 +71,14 @@ public class TimeBlockService {
 	}
 
 	private TimeBlock createTimeBlock(Team team, Position accessiblePosition, TimeBlockCreationRequest request) {
-		return TimeBlock.builder()
-			.name(request.name())
-			.color(request.color())
-			.accessiblePosition(accessiblePosition)
-			.startDate(request.startDate())
-			.endDate(request.endDate())
-			.team(team)
-			.build();
+		return TimeBlock.of(
+			request.name(),
+			request.color(),
+			accessiblePosition,
+			request.startDate(),
+			request.endDate(),
+			team
+		);
 	}
 
 	private void saveDocuments(List<String> filesUrl, TimeBlock timeBlock) {
@@ -86,9 +86,6 @@ public class TimeBlockService {
 	}
 
 	private Document createDocument(String fileUrl, TimeBlock timeBlock) {
-		return Document.builder()
-			.fileUrl(fileUrl)
-			.timeBlock(timeBlock)
-			.build();
+		return Document.of(fileUrl, timeBlock);
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tiki.server.common.entity.Position;
-import com.tiki.server.document.adapter.DocumentCreator;
+import com.tiki.server.document.adapter.DocumentSaver;
 import com.tiki.server.document.entity.Document;
 import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
 import com.tiki.server.team.adapter.TeamFinder;
 import com.tiki.server.team.entity.Team;
-import com.tiki.server.timeblock.adapter.TimeBlockCreator;
+import com.tiki.server.timeblock.adapter.TimeBlockSaver;
 import com.tiki.server.timeblock.dto.request.TimeBlockCreationRequest;
 import com.tiki.server.timeblock.dto.response.TimeBlockCreationResponse;
 import com.tiki.server.timeblock.entity.TimeBlock;
@@ -32,8 +32,8 @@ public class TimeBlockService {
 
 	private final TeamFinder teamFinder;
 	private final MemberTeamManagerFinder memberTeamManagerFinder;
-	private final TimeBlockCreator timeBlockCreator;
-	private final DocumentCreator documentCreator;
+	private final TimeBlockSaver timeBlockSaver;
+	private final DocumentSaver documentSaver;
 
 	@Transactional
 	public TimeBlockCreationResponse createTimeBlock(
@@ -59,7 +59,7 @@ public class TimeBlockService {
 	) {
 		checkMemberAccessible(accessiblePosition, memberPosition);
 		val timeBlock = createTimeBlock(team, accessiblePosition, request);
-		val timeBlockId = timeBlockCreator.createTimeBlock(timeBlock).getId();
+		val timeBlockId = timeBlockSaver.save(timeBlock).getId();
 		saveDocuments(request.filesUrl(), timeBlock);
 		return TimeBlockCreationResponse.of(timeBlockId);
 	}
@@ -82,7 +82,7 @@ public class TimeBlockService {
 	}
 
 	private void saveDocuments(List<String> filesUrl, TimeBlock timeBlock) {
-		filesUrl.forEach(fileUrl -> documentCreator.create(createDocument(fileUrl, timeBlock)));
+		filesUrl.forEach(fileUrl -> documentSaver.save(createDocument(fileUrl, timeBlock)));
 	}
 
 	private Document createDocument(String fileUrl, TimeBlock timeBlock) {

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -5,10 +5,14 @@ import static com.tiki.server.timeblock.message.ErrorCode.INVALID_TYPE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.MEMBER;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.tiki.server.common.entity.Position;
+import com.tiki.server.document.adapter.DocumentCreator;
+import com.tiki.server.document.entity.Document;
 import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
 import com.tiki.server.team.adapter.TeamFinder;
 import com.tiki.server.team.entity.Team;
@@ -29,7 +33,9 @@ public class TimeBlockService {
 	private final TeamFinder teamFinder;
 	private final MemberTeamManagerFinder memberTeamManagerFinder;
 	private final TimeBlockCreator timeBlockCreator;
+	private final DocumentCreator documentCreator;
 
+	@Transactional
 	public TimeBlockCreationResponse createTimeBlock(
 		long memberId,
 		long teamId,
@@ -54,6 +60,7 @@ public class TimeBlockService {
 		checkMemberAccessible(accessiblePosition, memberPosition);
 		val timeBlock = createTimeBlock(team, accessiblePosition, request);
 		val timeBlockId = timeBlockCreator.createTimeBlock(timeBlock).getId();
+		saveDocuments(request.filesUrl(), timeBlock);
 		return TimeBlockCreationResponse.of(timeBlockId);
 	}
 
@@ -71,6 +78,17 @@ public class TimeBlockService {
 			.startDate(request.startDate())
 			.endDate(request.endDate())
 			.team(team)
+			.build();
+	}
+
+	private void saveDocuments(List<String> filesUrl, TimeBlock timeBlock) {
+		filesUrl.forEach(fileUrl -> documentCreator.create(createDocument(fileUrl, timeBlock)));
+	}
+
+	private Document createDocument(String fileUrl, TimeBlock timeBlock) {
+		return Document.builder()
+			.fileUrl(fileUrl)
+			.timeBlock(timeBlock)
 			.build();
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -5,7 +5,7 @@ import static com.tiki.server.timeblock.message.ErrorCode.INVALID_TYPE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.MEMBER;
 
-import java.util.List;
+import java.util.Map;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -60,7 +60,7 @@ public class TimeBlockService {
 		checkMemberAccessible(accessiblePosition, memberPosition);
 		val timeBlock = createTimeBlock(team, accessiblePosition, request);
 		val timeBlockId = timeBlockSaver.save(timeBlock).getId();
-		saveDocuments(request.filesUrl(), timeBlock);
+		saveDocuments(request.files(), timeBlock);
 		return TimeBlockCreationResponse.of(timeBlockId);
 	}
 
@@ -81,11 +81,11 @@ public class TimeBlockService {
 		);
 	}
 
-	private void saveDocuments(List<String> filesUrl, TimeBlock timeBlock) {
-		filesUrl.forEach(fileUrl -> documentSaver.save(createDocument(fileUrl, timeBlock)));
+	private void saveDocuments(Map<String, String> files, TimeBlock timeBlock) {
+		files.forEach((fileName, fileUrl) -> documentSaver.save(createDocument(fileName, fileUrl, timeBlock)));
 	}
 
-	private Document createDocument(String fileUrl, TimeBlock timeBlock) {
-		return Document.of(fileUrl, timeBlock);
+	private Document createDocument(String fileName, String fileUrl, TimeBlock timeBlock) {
+		return Document.of(fileName, fileUrl, timeBlock);
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -1,13 +1,22 @@
 package com.tiki.server.timeblock.service;
 
+import static com.tiki.server.timeblock.message.ErrorCode.INVALID_AUTHORIZATION;
+import static com.tiki.server.timeblock.message.ErrorCode.INVALID_TYPE;
+import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
+import static com.tiki.server.timeblock.constant.TimeBlockConstant.MEMBER;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.tiki.server.member.adapter.MemberFinder;
+import com.tiki.server.common.entity.Position;
 import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
 import com.tiki.server.team.adapter.TeamFinder;
+import com.tiki.server.team.entity.Team;
+import com.tiki.server.timeblock.adapter.TimeBlockCreator;
 import com.tiki.server.timeblock.dto.request.TimeBlockCreationRequest;
 import com.tiki.server.timeblock.dto.response.TimeBlockCreationResponse;
+import com.tiki.server.timeblock.entity.TimeBlock;
+import com.tiki.server.timeblock.exception.TimeBlockException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -17,21 +26,51 @@ import lombok.val;
 @Transactional(readOnly = true)
 public class TimeBlockService {
 
-	private final MemberFinder memberFinder;
 	private final TeamFinder teamFinder;
 	private final MemberTeamManagerFinder memberTeamManagerFinder;
+	private final TimeBlockCreator timeBlockCreator;
 
-	public TimeBlockCreationResponse createTimeBlock(long memberId, long teamId, String type, TimeBlockCreationRequest request) {
-		val member = memberFinder.findById(memberId);
+	public TimeBlockCreationResponse createTimeBlock(
+		long memberId,
+		long teamId,
+		String type,
+		TimeBlockCreationRequest request
+	) {
 		val team = teamFinder.findById(teamId);
 		val position = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId).getPosition();
+		return switch (type) {
+			case EXECUTIVE -> createTimeBlockByType(team, Position.EXECUTIVE, position, request);
+			case MEMBER -> createTimeBlockByType(team, Position.MEMBER, position, request);
+			default -> throw new TimeBlockException(INVALID_TYPE);
+		};
 	}
 
-	private TimeBlockCreationResponse createExecutiveTimeBlock() {
-
+	private TimeBlockCreationResponse createTimeBlockByType(
+		Team team,
+		Position accessiblePosition,
+		Position memberPosition,
+		TimeBlockCreationRequest request
+	) {
+		checkMemberAccessible(accessiblePosition, memberPosition);
+		val timeBlock = createTimeBlock(team, accessiblePosition, request);
+		val timeBlockId = timeBlockCreator.createTimeBlock(timeBlock).getId();
+		return TimeBlockCreationResponse.of(timeBlockId);
 	}
 
-	private TimeBlockCreationResponse createMemberTimeBlock() {
+	private void checkMemberAccessible(Position accessiblePosition, Position memberPosition) {
+		if (accessiblePosition.getAuthorization() < memberPosition.getAuthorization()) {
+			throw new TimeBlockException(INVALID_AUTHORIZATION);
+		}
+	}
 
+	private TimeBlock createTimeBlock(Team team, Position accessiblePosition, TimeBlockCreationRequest request) {
+		return TimeBlock.builder()
+			.name(request.name())
+			.color(request.color())
+			.accessiblePosition(accessiblePosition)
+			.startDate(request.startDate())
+			.endDate(request.endDate())
+			.team(team)
+			.build();
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -71,14 +71,7 @@ public class TimeBlockService {
 	}
 
 	private TimeBlock createTimeBlock(Team team, Position accessiblePosition, TimeBlockCreationRequest request) {
-		return TimeBlock.of(
-			request.name(),
-			request.color(),
-			accessiblePosition,
-			request.startDate(),
-			request.endDate(),
-			team
-		);
+		return TimeBlock.of(team, accessiblePosition, request);
 	}
 
 	private void saveDocuments(Map<String, String> files, TimeBlock timeBlock) {


### PR DESCRIPTION
## ✨ Related Issue
- close #22 #27 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/Team-Tiki/TIKI_SERVER/assets/81404890/17eb9730-8ae8-4d70-ba1f-5a802c09f150)
- 타임 블록 생성

![image](https://github.com/Team-Tiki/TIKI_SERVER/assets/81404890/ede6b1d7-2d02-41e9-9e81-6eab7d576b56)
- 타임 블록 DB

![image](https://github.com/Team-Tiki/TIKI_SERVER/assets/81404890/b4ac58f2-3755-4faf-b730-9420615c2c98)
- 문서 DB

## 🐥 추가적인 언급 사항 
- 현재 회원, 팀 관련 로직이 구현되어있지 않기 때문에 더미 데이터를 통해 테스트하였습니다.
- 마찬가지로 Security 관련 로직이 완전하지 않기 때문에 테스트를 할 때는 SecurityConfig에서 permitAll(), Principal을 주석 처리하고 memberId를 PathVariable로 넣어주고 테스트하였습니다. -> 근데 그냥 memberId = 1L로 하면 됐네요..
- Doucment에서 휴지통 기능을 위해 deletedDate라는 컬럼을 가지고 있는데 문서 삭제가 될 때 status가 DELETED로 바뀌고 deletedDate가 설정되는 로직입니다. 때문에 deletedDate가 문서 삭제가 되기 전까지 null이라는 데이터를 가지고 있는 상황인데 더 좋은 방법이 있을 지 고민해주시면 감사하겠습니다.
- MEMBER, EXECUTIVE의 권한을 체크하는 방식에서 더 좋은 방식이 있는지 한 번 같이 고민해주시면 감사하겠습니다.