### PR TITLE
[FEAT] 타임 블록 상세 정보 조회

### DIFF
--- a/src/main/java/com/tiki/server/timeblock/adapter/TimeBlockFinder.java
+++ b/src/main/java/com/tiki/server/timeblock/adapter/TimeBlockFinder.java
@@ -1,10 +1,14 @@
 package com.tiki.server.timeblock.adapter;
 
+import static com.tiki.server.timeblock.message.ErrorCode.*;
+
 import java.util.List;
 
 import com.tiki.server.common.entity.Position;
 import com.tiki.server.common.support.RepositoryAdapter;
 import com.tiki.server.team.entity.Team;
+import com.tiki.server.timeblock.exception.TimeBlockException;
+import com.tiki.server.timeblock.message.ErrorCode;
 import com.tiki.server.timeblock.repository.TimeBlockRepository;
 import com.tiki.server.timeblock.vo.TimeBlockVO;
 
@@ -15,6 +19,12 @@ import lombok.RequiredArgsConstructor;
 public class TimeBlockFinder {
 
 	private final TimeBlockRepository timeBlockRepository;
+
+	public TimeBlockVO findById(long id) {
+		return timeBlockRepository.findById(id)
+			.map(TimeBlockVO::from)
+			.orElseThrow(() -> new TimeBlockException(INVALID_TIME_BLOCK));
+	}
 
 	public List<TimeBlockVO> findByTeamAndAccessiblePositionAndDate(
 		long teamId,

--- a/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
+++ b/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
@@ -3,6 +3,7 @@ package com.tiki.server.timeblock.controller;
 import static com.tiki.server.common.dto.SuccessResponse.*;
 import static com.tiki.server.timeblock.message.SuccessMessage.SUCCESS_CREATE_TIME_BLOCK;
 import static com.tiki.server.timeblock.message.SuccessMessage.SUCCESS_GET_TIMELINE;
+import static com.tiki.server.timeblock.message.SuccessMessage.SUCCESS_GET_TIME_BLOCK_DETAIL;
 
 import java.security.Principal;
 
@@ -20,6 +21,7 @@ import com.tiki.server.common.support.UriGenerator;
 import com.tiki.server.timeblock.controller.docs.TimeBlockControllerDocs;
 import com.tiki.server.timeblock.dto.request.TimeBlockCreateRequest;
 import com.tiki.server.timeblock.dto.response.TimeBlockCreateResponse;
+import com.tiki.server.timeblock.dto.response.TimeBlockDetailGetResponse;
 import com.tiki.server.timeblock.dto.response.TimelineGetResponse;
 import com.tiki.server.timeblock.service.TimeBlockService;
 
@@ -59,5 +61,16 @@ public class TimeBlockController implements TimeBlockControllerDocs {
 		val memberId = Long.parseLong(principal.getName());
 		val response = timeBlockService.getTimeline(memberId, teamId, type, date);
 		return ResponseEntity.ok().body(success(SUCCESS_GET_TIMELINE.getMessage(), response));
+	}
+
+	@GetMapping("/team/{teamId}/time-block/{timeBlockId}")
+	public ResponseEntity<SuccessResponse<TimeBlockDetailGetResponse>> getTimeBlockDetail(
+		// Principal principal,
+		@PathVariable long teamId,
+		@PathVariable long timeBlockId
+	) {
+		val memberId = 1L;// Long.parseLong(principal.getName());
+		val response = timeBlockService.getTimeBlockDetail(memberId, teamId, timeBlockId);
+		return ResponseEntity.ok().body(success(SUCCESS_GET_TIME_BLOCK_DETAIL.getMessage(), response));
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
+++ b/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
@@ -65,11 +65,11 @@ public class TimeBlockController implements TimeBlockControllerDocs {
 
 	@GetMapping("/team/{teamId}/time-block/{timeBlockId}")
 	public ResponseEntity<SuccessResponse<TimeBlockDetailGetResponse>> getTimeBlockDetail(
-		// Principal principal,
+		Principal principal,
 		@PathVariable long teamId,
 		@PathVariable long timeBlockId
 	) {
-		val memberId = 1L;// Long.parseLong(principal.getName());
+		val memberId = Long.parseLong(principal.getName());
 		val response = timeBlockService.getTimeBlockDetail(memberId, teamId, timeBlockId);
 		return ResponseEntity.ok().body(success(SUCCESS_GET_TIME_BLOCK_DETAIL.getMessage(), response));
 	}

--- a/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
+++ b/src/main/java/com/tiki/server/timeblock/controller/TimeBlockController.java
@@ -49,7 +49,7 @@ public class TimeBlockController implements TimeBlockControllerDocs {
 	}
 
 	@Override
-	@GetMapping("team/{teamId}/timeline")
+	@GetMapping("/team/{teamId}/timeline")
 	public ResponseEntity<SuccessResponse<TimelineGetResponse>> getTimeline(
 		Principal principal,
 		@PathVariable long teamId,

--- a/src/main/java/com/tiki/server/timeblock/dto/response/TimeBlockDetailGetResponse.java
+++ b/src/main/java/com/tiki/server/timeblock/dto/response/TimeBlockDetailGetResponse.java
@@ -1,0 +1,38 @@
+package com.tiki.server.timeblock.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import java.util.List;
+
+import com.tiki.server.document.vo.DocumentVO;
+
+import lombok.Builder;
+import lombok.NonNull;
+
+@Builder(access = PRIVATE)
+public record TimeBlockDetailGetResponse(
+	List<DocumentGetResponse> documents
+) {
+
+	public static TimeBlockDetailGetResponse from(List<DocumentVO> documents) {
+		return TimeBlockDetailGetResponse.builder()
+			.documents(documents.stream().map(DocumentGetResponse::from).toList())
+			.build();
+	}
+
+	@Builder(access = PRIVATE)
+	public record DocumentGetResponse(
+		long documentId,
+		@NonNull String fileName,
+		@NonNull String fileUrl
+	) {
+
+		public static DocumentGetResponse from(DocumentVO document) {
+			return DocumentGetResponse.builder()
+				.documentId(document.documentId())
+				.fileName(document.fileName())
+				.fileUrl(document.fileUrl())
+				.build();
+		}
+	}
+}

--- a/src/main/java/com/tiki/server/timeblock/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/timeblock/message/ErrorCode.java
@@ -2,6 +2,7 @@ package com.tiki.server.timeblock.message;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import org.springframework.http.HttpStatus;
 
@@ -16,7 +17,10 @@ public enum ErrorCode {
 	INVALID_TYPE(BAD_REQUEST, "유효한 타입이 아닙니다."),
 
 	/* 403 FORBIDDEN : 권한 없음 */
-	INVALID_AUTHORIZATION(FORBIDDEN, "타임블록에 대한 권한이 없습니다.");
+	INVALID_AUTHORIZATION(FORBIDDEN, "타임블록에 대한 권한이 없습니다."),
+
+	/* 404 NOT_FOUND : 자원을 찾을 수 없음 */
+	INVALID_TIME_BLOCK(NOT_FOUND, "유효하지 않은 타임 블록입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/tiki/server/timeblock/message/SuccessMessage.java
+++ b/src/main/java/com/tiki/server/timeblock/message/SuccessMessage.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum SuccessMessage {
 
 	SUCCESS_CREATE_TIME_BLOCK("타임 블록 생성 성공"),
-	SUCCESS_GET_TIMELINE("타임라인 조회 성공");
+	SUCCESS_GET_TIMELINE("타임라인 조회 성공"),
+	SUCCESS_GET_TIME_BLOCK_DETAIL("타임 블록 상세 정보 조회 성공");
 
 	private final String message;
 }

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -5,7 +5,6 @@ import static com.tiki.server.timeblock.message.ErrorCode.INVALID_TYPE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.MEMBER;
 
-import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
@@ -15,7 +14,6 @@ import com.tiki.server.common.entity.Position;
 import com.tiki.server.document.adapter.DocumentFinder;
 import com.tiki.server.document.adapter.DocumentSaver;
 import com.tiki.server.document.entity.Document;
-import com.tiki.server.document.vo.DocumentVO;
 import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
 import com.tiki.server.team.adapter.TeamFinder;
 import com.tiki.server.team.entity.Team;
@@ -23,10 +21,10 @@ import com.tiki.server.timeblock.adapter.TimeBlockFinder;
 import com.tiki.server.timeblock.adapter.TimeBlockSaver;
 import com.tiki.server.timeblock.dto.request.TimeBlockCreateRequest;
 import com.tiki.server.timeblock.dto.response.TimeBlockCreateResponse;
+import com.tiki.server.timeblock.dto.response.TimeBlockDetailGetResponse;
 import com.tiki.server.timeblock.dto.response.TimelineGetResponse;
 import com.tiki.server.timeblock.entity.TimeBlock;
 import com.tiki.server.timeblock.exception.TimeBlockException;
-import com.tiki.server.timeblock.vo.TimeBlockVO;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
@@ -67,6 +65,14 @@ public class TimeBlockService {
 			case MEMBER -> getTimelineByType(team, Position.MEMBER, position, date);
 			default -> throw new TimeBlockException(INVALID_TYPE);
 		};
+	}
+
+	public TimeBlockDetailGetResponse getTimeBlockDetail(long memberId, long teamId, long timeBlockId) {
+		val position = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId).getPosition();
+		val timeBlock = timeBlockFinder.findById(timeBlockId);
+		checkMemberAccessible(timeBlock.accessiblePosition(), position);
+		val documents = documentFinder.findAllByTimeBlockId(timeBlockId);
+		return TimeBlockDetailGetResponse.from(documents);
 	}
 
 	private TimeBlockCreateResponse createTimeBlockByType(

--- a/src/main/java/com/tiki/server/timeblock/vo/TimeBlockVO.java
+++ b/src/main/java/com/tiki/server/timeblock/vo/TimeBlockVO.java
@@ -4,6 +4,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 import java.time.LocalDate;
 
+import com.tiki.server.common.entity.Position;
 import com.tiki.server.timeblock.entity.TimeBlock;
 
 import lombok.Builder;
@@ -14,6 +15,7 @@ public record TimeBlockVO(
 	long timeBlockId,
 	@NonNull String name,
 	@NonNull String color,
+	@NonNull Position accessiblePosition,
 	@NonNull LocalDate startDate,
 	@NonNull LocalDate endDate
 ) {
@@ -23,6 +25,7 @@ public record TimeBlockVO(
 			.timeBlockId(timeBlock.getId())
 			.name(timeBlock.getName())
 			.color(timeBlock.getColor())
+			.accessiblePosition(timeBlock.getAccessiblePosition())
 			.startDate(timeBlock.getStartDate())
 			.endDate(timeBlock.getEndDate())
 			.build();


### PR DESCRIPTION
## ✨ Related Issue
- close #49 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/user-attachments/assets/d69b2d48-ba91-4fe7-89d2-5c99b54d826d)
- 타임 블록 상세 정보 조회 api

## 🐥 추가적인 언급 사항
- 타임라인 조회 api에서 블록에 대한 정보를 대부분 보내주고 있기 때문에 클라랑 합의 후 문서 정보들만 전송합니다.