### PR TITLE
[FEAT] 비밀번호 변경 API 추가

### DIFF
--- a/src/main/java/com/tiki/server/member/controller/MemberController.java
+++ b/src/main/java/com/tiki/server/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.tiki.server.member.controller;
 
 import com.tiki.server.common.dto.SuccessResponse;
 import com.tiki.server.member.controller.docs.MemberControllerDocs;
+import com.tiki.server.member.dto.request.ChangingPasswordRequest;
 import com.tiki.server.member.dto.request.MemberProfileCreateRequest;
 import com.tiki.server.common.dto.BaseResponse;
 import com.tiki.server.member.dto.response.BelongTeamsGetResponse;
@@ -14,10 +15,10 @@ import com.tiki.server.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 
 import java.security.Principal;
-import java.util.List;
 
 import static com.tiki.server.common.dto.SuccessResponse.success;
 import static com.tiki.server.common.support.UriGenerator.getUri;
+import static com.tiki.server.member.message.SuccessMessage.SUCCESS_CHANGING_PASSWORD;
 import static com.tiki.server.member.message.SuccessMessage.SUCCESS_CREATE_MEMBER;
 import static com.tiki.server.team.message.SuccessMessage.SUCCESS_GET_JOINED_TEAM;
 
@@ -43,5 +44,13 @@ public class MemberController implements MemberControllerDocs {
         val memberId = Long.parseLong(principal.getName());
         val response = memberService.findBelongTeams(memberId);
         return ResponseEntity.ok().body(success(SUCCESS_GET_JOINED_TEAM.getMessage(), response));
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<BaseResponse> changePassword(
+            @RequestBody ChangingPasswordRequest changingPasswordRequest
+    ) {
+        memberService.changePassword(changingPasswordRequest);
+        return ResponseEntity.created(getUri("/")).body(success(SUCCESS_CHANGING_PASSWORD.getMessage()));
     }
 }

--- a/src/main/java/com/tiki/server/member/controller/MemberController.java
+++ b/src/main/java/com/tiki/server/member/controller/MemberController.java
@@ -2,7 +2,7 @@ package com.tiki.server.member.controller;
 
 import com.tiki.server.common.dto.SuccessResponse;
 import com.tiki.server.member.controller.docs.MemberControllerDocs;
-import com.tiki.server.member.dto.request.ChangingPasswordRequest;
+import com.tiki.server.member.dto.request.PasswordChangeRequest;
 import com.tiki.server.member.dto.request.MemberProfileCreateRequest;
 import com.tiki.server.common.dto.BaseResponse;
 import com.tiki.server.member.dto.response.BelongTeamsGetResponse;
@@ -48,9 +48,9 @@ public class MemberController implements MemberControllerDocs {
 
     @PatchMapping("/password")
     public ResponseEntity<BaseResponse> changePassword(
-            @RequestBody ChangingPasswordRequest changingPasswordRequest
+            @RequestBody PasswordChangeRequest passwordChangeRequest
     ) {
-        memberService.changePassword(changingPasswordRequest);
-        return ResponseEntity.created(getUri("/")).body(success(SUCCESS_CHANGING_PASSWORD.getMessage()));
+        memberService.changePassword(passwordChangeRequest);
+        return ResponseEntity.ok().body(success(SUCCESS_CHANGING_PASSWORD.getMessage()));
     }
 }

--- a/src/main/java/com/tiki/server/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/tiki/server/member/controller/docs/MemberControllerDocs.java
@@ -3,6 +3,7 @@ package com.tiki.server.member.controller.docs;
 import com.tiki.server.common.dto.BaseResponse;
 import com.tiki.server.common.dto.ErrorResponse;
 import com.tiki.server.common.dto.SuccessResponse;
+import com.tiki.server.member.dto.request.ChangingPasswordRequest;
 import com.tiki.server.member.dto.request.MemberProfileCreateRequest;
 import com.tiki.server.member.dto.response.BelongTeamsGetResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -72,5 +73,34 @@ public interface MemberControllerDocs {
     )
     ResponseEntity<SuccessResponse<BelongTeamsGetResponse>> getBelongTeam(
             @Parameter(hidden = true) Principal principal
+    );
+
+    @Operation(
+            summary = "비밀번호 변경",
+            description = "비밀번호를 변경합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "성공",
+                            content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+                    @ApiResponse(
+                            responseCode = "400",
+                            description = "비밀번호가 일치하지 않습니다.",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "유효하지 않은 회원",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(
+                            responseCode = "4xx",
+                            description = "클라이언트(요청) 오류",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+                    @ApiResponse(
+                            responseCode = "500",
+                            description = "서버 내부 오류",
+                            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))}
+    )
+    ResponseEntity<BaseResponse> changePassword(
+            @RequestBody ChangingPasswordRequest changingPasswordRequest
     );
 }

--- a/src/main/java/com/tiki/server/member/controller/docs/MemberControllerDocs.java
+++ b/src/main/java/com/tiki/server/member/controller/docs/MemberControllerDocs.java
@@ -3,7 +3,7 @@ package com.tiki.server.member.controller.docs;
 import com.tiki.server.common.dto.BaseResponse;
 import com.tiki.server.common.dto.ErrorResponse;
 import com.tiki.server.common.dto.SuccessResponse;
-import com.tiki.server.member.dto.request.ChangingPasswordRequest;
+import com.tiki.server.member.dto.request.PasswordChangeRequest;
 import com.tiki.server.member.dto.request.MemberProfileCreateRequest;
 import com.tiki.server.member.dto.response.BelongTeamsGetResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -100,6 +100,6 @@ public interface MemberControllerDocs {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))}
     )
     ResponseEntity<BaseResponse> changePassword(
-            @RequestBody ChangingPasswordRequest changingPasswordRequest
+            @RequestBody PasswordChangeRequest passwordChangeRequest
     );
 }

--- a/src/main/java/com/tiki/server/member/dto/request/ChangingPasswordRequest.java
+++ b/src/main/java/com/tiki/server/member/dto/request/ChangingPasswordRequest.java
@@ -1,0 +1,10 @@
+package com.tiki.server.member.dto.request;
+
+import lombok.NonNull;
+
+public record ChangingPasswordRequest(
+        @NonNull String email,
+        @NonNull String password,
+        @NonNull String passwordChecker
+) {
+}

--- a/src/main/java/com/tiki/server/member/dto/request/PasswordChangeRequest.java
+++ b/src/main/java/com/tiki/server/member/dto/request/PasswordChangeRequest.java
@@ -2,7 +2,7 @@ package com.tiki.server.member.dto.request;
 
 import lombok.NonNull;
 
-public record ChangingPasswordRequest(
+public record PasswordChangeRequest(
         @NonNull String email,
         @NonNull String password,
         @NonNull String passwordChecker

--- a/src/main/java/com/tiki/server/member/entity/Member.java
+++ b/src/main/java/com/tiki/server/member/entity/Member.java
@@ -48,7 +48,7 @@ public class Member extends BaseTime {
                 .build();
     }
 
-    public void setPassword(String password) {
+    public void resetPassword(String password) {
         this.password = password;
     }
 }

--- a/src/main/java/com/tiki/server/member/entity/Member.java
+++ b/src/main/java/com/tiki/server/member/entity/Member.java
@@ -47,4 +47,8 @@ public class Member extends BaseTime {
                 .univ(univ)
                 .build();
     }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/tiki/server/member/message/SuccessMessage.java
+++ b/src/main/java/com/tiki/server/member/message/SuccessMessage.java
@@ -7,7 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SuccessMessage {
 
-    SUCCESS_CREATE_MEMBER("회원가입 성공");
+    SUCCESS_CREATE_MEMBER("회원가입 성공"),
+    SUCCESS_CHANGING_PASSWORD("비밀번호 변경 성공");
 
     private final String message;
 }

--- a/src/main/java/com/tiki/server/member/service/MemberService.java
+++ b/src/main/java/com/tiki/server/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.tiki.server.member.service;
 
 import com.tiki.server.member.adapter.MemberFinder;
 import com.tiki.server.member.adapter.MemberSaver;
+import com.tiki.server.member.dto.request.ChangingPasswordRequest;
 import com.tiki.server.member.dto.request.MemberProfileCreateRequest;
 import com.tiki.server.member.dto.response.BelongTeamsGetResponse;
 import com.tiki.server.member.entity.Member;
@@ -14,8 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 
-import static com.tiki.server.member.message.ErrorCode.CONFLICT_MEMBER;
-import static com.tiki.server.member.message.ErrorCode.UNMATCHED_PASSWORD;
+import static com.tiki.server.member.message.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +33,17 @@ public class MemberService {
         checkPassword(request.password(), request.passwordChecker());
         val member = createMember(request);
         saveMember(member);
+    }
+
+    @Transactional
+    public void changePassword(ChangingPasswordRequest request) {
+        val member = checkMemberEmpty(request);
+        checkPassword(request.password(), request.passwordChecker());
+        member.setPassword(passwordEncoder.encode(request.password()));
+    }
+
+    private Member checkMemberEmpty(ChangingPasswordRequest request) {
+        return memberFinder.findByEmail(request.email()).orElseThrow(() -> new MemberException(INVALID_MEMBER));
     }
 
     private void checkMailDuplicate(String email) {

--- a/src/main/java/com/tiki/server/member/service/MemberService.java
+++ b/src/main/java/com/tiki/server/member/service/MemberService.java
@@ -2,7 +2,7 @@ package com.tiki.server.member.service;
 
 import com.tiki.server.member.adapter.MemberFinder;
 import com.tiki.server.member.adapter.MemberSaver;
-import com.tiki.server.member.dto.request.ChangingPasswordRequest;
+import com.tiki.server.member.dto.request.PasswordChangeRequest;
 import com.tiki.server.member.dto.request.MemberProfileCreateRequest;
 import com.tiki.server.member.dto.response.BelongTeamsGetResponse;
 import com.tiki.server.member.entity.Member;
@@ -36,13 +36,13 @@ public class MemberService {
     }
 
     @Transactional
-    public void changePassword(ChangingPasswordRequest request) {
+    public void changePassword(PasswordChangeRequest request) {
         val member = checkMemberEmpty(request);
         checkPassword(request.password(), request.passwordChecker());
-        member.setPassword(passwordEncoder.encode(request.password()));
+        member.resetPassword(passwordEncoder.encode(request.password()));
     }
 
-    private Member checkMemberEmpty(ChangingPasswordRequest request) {
+    private Member checkMemberEmpty(PasswordChangeRequest request) {
         return memberFinder.findByEmail(request.email()).orElseThrow(() -> new MemberException(INVALID_MEMBER));
     }
 


### PR DESCRIPTION
## ✨ Related Issue
- close #96 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/user-attachments/assets/3050c28b-1930-480c-8ab7-58e45d44d44f)
비밀번호 변경 성공

![image](https://github.com/user-attachments/assets/0e7ae1aa-8402-47d1-a493-5d1221a4c82f)
존재하지 않은 유저

![image](https://github.com/user-attachments/assets/f3b01e44-dc00-4359-9898-ca125994d28f)
비밀번호 불일치

## 🐥 추가적인 언급 사항
* 현재 이전 PR에서 언급하신 이메일로 멤버를 찾는 로직에서 중복되는 메서드가 많아서 이 PR까지 머지 후 한번에 리팩토링 진행하겠습니다.
