### PR TITLE
[REFACTOR] 전체 문서 조회 전달 데이터 추가

### DIFF
--- a/src/main/java/com/tiki/server/document/adapter/DocumentFinder.java
+++ b/src/main/java/com/tiki/server/document/adapter/DocumentFinder.java
@@ -24,8 +24,7 @@ public class DocumentFinder {
 		return documentRepository.findAllByTimeBlockId(timeBlockId).stream().map(DocumentVO::from).toList();
 	}
 
-	public List<DocumentVO> findAllByTeamIdAndAccessiblePosition(long teamId, Position accessiblePosition) {
-		return documentRepository.findAllByTeamIdAndAccessiblePosition(teamId, accessiblePosition).stream()
-			.map(DocumentVO::from).toList();
+	public List<Document> findAllByTeamIdAndAccessiblePosition(long teamId, Position accessiblePosition) {
+		return documentRepository.findAllByTeamIdAndAccessiblePosition(teamId, accessiblePosition);
 	}
 }

--- a/src/main/java/com/tiki/server/document/dto/response/DocumentsGetResponse.java
+++ b/src/main/java/com/tiki/server/document/dto/response/DocumentsGetResponse.java
@@ -4,7 +4,7 @@ import static lombok.AccessLevel.PRIVATE;
 
 import java.util.List;
 
-import com.tiki.server.document.vo.DocumentVO;
+import com.tiki.server.document.entity.Document;
 
 import lombok.Builder;
 import lombok.NonNull;
@@ -14,7 +14,7 @@ public record DocumentsGetResponse(
 	List<DocumentGetResponse> documents
 ) {
 
-	public static DocumentsGetResponse from(List<DocumentVO> documents) {
+	public static DocumentsGetResponse from(List<Document> documents) {
 		return DocumentsGetResponse.builder()
 			.documents(documents.stream().map(DocumentGetResponse::from).toList())
 			.build();
@@ -24,14 +24,18 @@ public record DocumentsGetResponse(
 	private record DocumentGetResponse(
 		long documentId,
 		@NonNull String fileName,
-		@NonNull String fileUrl
+		@NonNull String fileUrl,
+		@NonNull String blockName,
+		@NonNull String color
 	) {
 
-		public static DocumentGetResponse from(DocumentVO document) {
+		public static DocumentGetResponse from(Document document) {
 			return DocumentGetResponse.builder()
-				.documentId(document.documentId())
-				.fileName(document.fileName())
-				.fileUrl(document.fileUrl())
+				.documentId(document.getId())
+				.fileName(document.getFileName())
+				.fileUrl(document.getFileUrl())
+				.blockName(document.getTimeBlock().getName())
+				.color(document.getTimeBlock().getColor())
 				.build();
 		}
 	}

--- a/src/main/java/com/tiki/server/document/repository/DocumentRepository.java
+++ b/src/main/java/com/tiki/server/document/repository/DocumentRepository.java
@@ -11,7 +11,7 @@ import com.tiki.server.document.entity.Document;
 public interface DocumentRepository extends JpaRepository<Document, Long> {
 	List<Document> findAllByTimeBlockId(long timeBlockId);
 
-	@Query("select d from Document d join d.timeBlock t "
+	@Query("select d from Document d join fetch d.timeBlock t "
 		+ "where t.team.id = :teamId and t.accessiblePosition = :position order by d.createdAt asc")
 	List<Document> findAllByTeamIdAndAccessiblePosition(long teamId, Position position);
 

--- a/src/main/java/com/tiki/server/team/controller/TeamController.java
+++ b/src/main/java/com/tiki/server/team/controller/TeamController.java
@@ -48,6 +48,7 @@ public class TeamController implements TeamControllerDocs {
         return ResponseEntity.ok().body(success(SUCCESS_GET_TEAMS.getMessage(), response));
     }
 
+    @Override
     @GetMapping("/category")
     public ResponseEntity<SuccessResponse<CategoriesGetResponse>> getCategories() {
         val response = teamService.getCategories();

--- a/src/main/java/com/tiki/server/team/controller/docs/TeamControllerDocs.java
+++ b/src/main/java/com/tiki/server/team/controller/docs/TeamControllerDocs.java
@@ -2,6 +2,7 @@ package com.tiki.server.team.controller.docs;
 
 import java.security.Principal;
 
+import com.tiki.server.team.dto.response.CategoriesGetResponse;
 import com.tiki.server.team.dto.response.TeamsGetResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -69,4 +70,23 @@ public interface TeamControllerDocs {
                             content = @Content(schema = @Schema(implementation = ErrorResponse.class)))}
     )
     ResponseEntity<SuccessResponse<TeamsGetResponse>> getAllTeam(Principal principal);
+
+    @Operation(
+        summary = "카테고리 조회",
+        description = "카테고리 리스트를 조회한다.",
+        responses = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공",
+                content = @Content(schema = @Schema(implementation = SuccessResponse.class))),
+            @ApiResponse(
+                responseCode = "4xx",
+                description = "클라이언트(요청) 오류",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(
+                responseCode = "500",
+                description = "서버 내부 오류",
+                content = @Content(schema = @Schema(implementation = ErrorResponse.class)))}
+    )
+    ResponseEntity<SuccessResponse<CategoriesGetResponse>> getCategories();
 }


### PR DESCRIPTION
## ✨ Related Issue
- close #104 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/user-attachments/assets/b168943a-b6ea-4c44-8211-c22f1ff02f4e)
- 전체 문서 조회

## 🐥 추가적인 언급 사항
- 타임블록 정보도 필요하므로 join -> fetch join으로 변경하였습니다.
- 클라이언트 api 매칭을 위해 승인 없이 머지하도록 하겠습니다.