### PR TITLE
[REFACTOR] Member 도메인 리팩토링

### DIFF
--- a/src/main/java/com/tiki/server/common/config/CorsConfig.java
+++ b/src/main/java/com/tiki/server/common/config/CorsConfig.java
@@ -29,7 +29,7 @@ public class CorsConfig {
     private CorsConfiguration setCorsConfiguration() {
         val config = new CorsConfiguration();
         config.setAllowCredentials(true);
-        config.addAllowedOrigin(("https://tiki-client.vercel.app"));
+        config.addAllowedOrigin(("https://ti-kii.com"));
         config.addAllowedOrigin("http://localhost:5173");
         config.addAllowedOrigin("https://www.tiki-sopt.p-e.kr");
         config.addAllowedHeader("*");

--- a/src/main/java/com/tiki/server/member/adapter/MemberFinder.java
+++ b/src/main/java/com/tiki/server/member/adapter/MemberFinder.java
@@ -1,5 +1,6 @@
 package com.tiki.server.member.adapter;
 
+import static com.tiki.server.member.message.ErrorCode.CONFLICT_MEMBER;
 import static com.tiki.server.member.message.ErrorCode.INVALID_MEMBER;
 
 import com.tiki.server.common.support.RepositoryAdapter;
@@ -23,6 +24,16 @@ public class MemberFinder {
 
     public Member findById(long memberId) {
         return memberRepository.findById(memberId)
-            .orElseThrow(() -> new MemberException(INVALID_MEMBER));
+                .orElseThrow(() -> new MemberException(INVALID_MEMBER));
+    }
+
+    public Member checkEmpty(String email) {
+        return findByEmail(email).orElseThrow(() -> new MemberException(INVALID_MEMBER));
+    }
+
+    public void checkPresent(String email) {
+        findByEmail(email).ifPresent((member) -> {
+            throw new MemberException(CONFLICT_MEMBER);
+        });
     }
 }

--- a/src/main/java/com/tiki/server/member/adapter/MemberFinder.java
+++ b/src/main/java/com/tiki/server/member/adapter/MemberFinder.java
@@ -23,8 +23,7 @@ public class MemberFinder {
     }
 
     public Member findById(long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(INVALID_MEMBER));
+        return memberRepository.findById(memberId).orElseThrow(() -> new MemberException(INVALID_MEMBER));
     }
 
     public Member checkEmpty(String email) {

--- a/src/main/java/com/tiki/server/member/entity/Member.java
+++ b/src/main/java/com/tiki/server/member/entity/Member.java
@@ -1,8 +1,13 @@
 package com.tiki.server.member.entity;
 
+import static com.tiki.server.mail.constants.MailConstants.MAIL_FORMAT_AC_KR;
+import static com.tiki.server.mail.constants.MailConstants.MAIL_FORMAT_EDU;
+import static com.tiki.server.member.message.ErrorCode.INVALID_EMAIL;
+import static com.tiki.server.member.message.ErrorCode.UNMATCHED_PASSWORD;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
+import com.tiki.server.member.exception.MemberException;
 import java.time.LocalDate;
 
 import com.tiki.server.common.entity.BaseTime;
@@ -38,17 +43,36 @@ public class Member extends BaseTime {
     @Enumerated(value = STRING)
     private University univ;
 
-    public static Member of(String email, String password, String name, LocalDate birth, University univ) {
-        return Member.builder()
+    public static Member of(String email, String password, String passwordChecker, String name, LocalDate birth,
+                            University univ) {
+
+        val member = Member.builder()
                 .email(email)
                 .password(password)
                 .name(name)
                 .birth(birth)
                 .univ(univ)
                 .build();
+
+        member.checkMailFormat();
+        member.checkPassword(passwordChecker);
+        return member;
     }
 
     public void resetPassword(String password) {
+        checkPassword(password);
         this.password = password;
+    }
+
+    private void checkMailFormat() {
+        if (!(this.email.endsWith(MAIL_FORMAT_EDU) || this.email.endsWith(MAIL_FORMAT_AC_KR))) {
+            throw new MemberException(INVALID_EMAIL);
+        }
+    }
+
+    private void checkPassword(String passwordChecker) {
+        if (!this.password.equals(passwordChecker)) {
+            throw new MemberException(UNMATCHED_PASSWORD);
+        }
     }
 }

--- a/src/main/java/com/tiki/server/member/entity/Member.java
+++ b/src/main/java/com/tiki/server/member/entity/Member.java
@@ -43,9 +43,13 @@ public class Member extends BaseTime {
     @Enumerated(value = STRING)
     private University univ;
 
-    public static Member of(String email, String password, String passwordChecker, String name, LocalDate birth,
-                            University univ) {
-
+    public static Member of(
+            String email,
+            String password,
+            String passwordChecker,
+            String name,
+            LocalDate birth,
+            University univ) {
         val member = Member.builder()
                 .email(email)
                 .password(password)

--- a/src/main/java/com/tiki/server/member/entity/Member.java
+++ b/src/main/java/com/tiki/server/member/entity/Member.java
@@ -55,24 +55,16 @@ public class Member extends BaseTime {
                 .build();
 
         member.checkMailFormat();
-        member.checkPassword(passwordChecker);
         return member;
     }
 
     public void resetPassword(String password) {
-        checkPassword(password);
         this.password = password;
     }
 
     private void checkMailFormat() {
         if (!(this.email.endsWith(MAIL_FORMAT_EDU) || this.email.endsWith(MAIL_FORMAT_AC_KR))) {
             throw new MemberException(INVALID_EMAIL);
-        }
-    }
-
-    private void checkPassword(String passwordChecker) {
-        if (!this.password.equals(passwordChecker)) {
-            throw new MemberException(UNMATCHED_PASSWORD);
         }
     }
 }

--- a/src/main/java/com/tiki/server/member/service/MemberService.java
+++ b/src/main/java/com/tiki/server/member/service/MemberService.java
@@ -64,7 +64,6 @@ public class MemberService {
         memberSaver.save(member);
     }
 
-
     public BelongTeamsGetResponse findBelongTeams(long memberId) {
         return BelongTeamsGetResponse.from(memberTeamManagerFinder.findBelongTeamByMemberId(memberId));
     }

--- a/src/main/java/com/tiki/server/member/service/MemberService.java
+++ b/src/main/java/com/tiki/server/member/service/MemberService.java
@@ -31,45 +31,22 @@ public class MemberService {
 
     @Transactional
     public void signUp(MemberProfileCreateRequest request) {
-        checkMailFormat(request.email());
-        checkMailDuplicate(request.email());
-        checkPassword(request.password(), request.passwordChecker());
+        memberFinder.checkPresent(request.email());
         val member = createMember(request);
         saveMember(member);
     }
 
     @Transactional
     public void changePassword(PasswordChangeRequest request) {
-        val member = checkMemberEmpty(request);
-        checkPassword(request.password(), request.passwordChecker());
+        val member = memberFinder.checkEmpty(request.email());
         member.resetPassword(passwordEncoder.encode(request.password()));
-    }
-
-    private Member checkMemberEmpty(PasswordChangeRequest request) {
-        return memberFinder.findByEmail(request.email()).orElseThrow(() -> new MemberException(INVALID_MEMBER));
-    }
-
-    private void checkMailDuplicate(String email) {
-        memberFinder.findByEmail(email).ifPresent(member -> {
-            throw new MemberException(CONFLICT_MEMBER);
-        });
-    }
-    private void checkMailFormat(String email){
-        if (!(email.endsWith(MAIL_FORMAT_EDU) || email.endsWith(MAIL_FORMAT_AC_KR))) {
-            throw new MemberException(INVALID_EMAIL);
-        }
-    }
-
-    private void checkPassword(String password, String passwordChecker) {
-        if (!password.equals(passwordChecker)) {
-            throw new MemberException(UNMATCHED_PASSWORD);
-        }
     }
 
     private Member createMember(MemberProfileCreateRequest request) {
         return Member.of(
                 request.email(),
                 passwordEncoder.encode(request.password()),
+                passwordEncoder.encode(request.passwordChecker()),
                 request.name(),
                 request.birth(),
                 request.univ());

--- a/src/main/java/com/tiki/server/member/service/MemberService.java
+++ b/src/main/java/com/tiki/server/member/service/MemberService.java
@@ -6,7 +6,6 @@ import com.tiki.server.member.dto.request.PasswordChangeRequest;
 import com.tiki.server.member.dto.request.MemberProfileCreateRequest;
 import com.tiki.server.member.dto.response.BelongTeamsGetResponse;
 import com.tiki.server.member.entity.Member;
-import com.tiki.server.member.exception.MemberException;
 import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
 import lombok.val;
 import org.springframework.security.crypto.password.PasswordEncoder;


### PR DESCRIPTION
## ✨ Related Issue
- close #130 
  <br/>

## 📝 기능 구현 명세

## 🐥 추가적인 언급 사항
- ### 오류 발견되었습니다
- 우선 멤버 서비스에서 사용되던 멤버가 존재하는지 존재하지 않는지 확인하는 메서드들을 MemberFinder로 옮겼습니다. 이에 대한 메서드 네이밍을 현재 한것처럼 할 지 두개의 메서드 네이밍을 반대로 할 지 고민했는데 안에서 사용되고 있는 ifPresent라는 메서드의 이름을 따라서 네이밍을 했습니다.
- Member 도메인 안에서 checkMailFormat과 checkPassword 같은 메서드들을 static으로 할 지 그냥 일반 메서드로 할 지 고민하다가 객체 중심적으로 생각했을때 그 객체가 생성되고 객체가 어떤 일을 하는 것이니 static 사용하지 않고 메서드를 생성했습니다.
- 고민되는게 있거나 이런 방향으로 하는게 확실하지 않은것 같으면 수요일에 가져가서 이런식으로 바꾸면 되는 것 인지 확인해봐도 좋을 것 같습니다
