### PR TITLE
[REFACTOR] refresh token 쿠키로 처리

### DIFF
--- a/src/main/java/com/tiki/server/auth/controller/AuthController.java
+++ b/src/main/java/com/tiki/server/auth/controller/AuthController.java
@@ -1,4 +1,5 @@
 package com.tiki.server.auth.controller;
+
 import com.tiki.server.auth.dto.request.LoginRequest;
 import com.tiki.server.auth.dto.response.ReissueGetResponse;
 import com.tiki.server.common.dto.SuccessResponse;
@@ -39,7 +40,7 @@ public class AuthController {
 
     @GetMapping("/reissue")
     public ResponseEntity<SuccessResponse<ReissueGetResponse>> reissue(
-            @CookieValue(name = "refreshToken", required = false)String refreshToken
+            @CookieValue(name = "refreshToken") String refreshToken
     ) {
         val response = authService.reissueToken(refreshToken);
         return ResponseEntity.created(UriGenerator.getUri("/"))

--- a/src/main/java/com/tiki/server/auth/controller/AuthController.java
+++ b/src/main/java/com/tiki/server/auth/controller/AuthController.java
@@ -38,8 +38,10 @@ public class AuthController {
     }
 
     @GetMapping("/reissue")
-    public ResponseEntity<SuccessResponse<ReissueGetResponse>> reissue(HttpServletRequest httpServletRequest) {
-        val response = authService.reissueToken(httpServletRequest);
+    public ResponseEntity<SuccessResponse<ReissueGetResponse>> reissue(
+            @CookieValue(name = "refreshToken", required = false)String refreshToken
+    ) {
+        val response = authService.reissueToken(refreshToken);
         return ResponseEntity.created(UriGenerator.getUri("/"))
                 .body(SuccessResponse.success(SUCCESS_REISSUE_ACCESS_TOKEN.getMessage(), response));
     }

--- a/src/main/java/com/tiki/server/auth/service/AuthService.java
+++ b/src/main/java/com/tiki/server/auth/service/AuthService.java
@@ -11,7 +11,6 @@ import com.tiki.server.auth.token.entity.Token;
 import com.tiki.server.member.adapter.MemberFinder;
 import com.tiki.server.member.entity.Member;
 import com.tiki.server.member.exception.MemberException;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
@@ -54,9 +53,7 @@ public class AuthService {
         return SignInGetResponse.from(accessToken, refreshToken);
     }
 
-    public ReissueGetResponse reissueToken(HttpServletRequest request) {
-        System.out.println("1");
-        val refreshToken = jwtProvider.getTokenFromRequest(request);
+    public ReissueGetResponse reissueToken(String refreshToken) {
         checkTokenEmpty(refreshToken);
         val memberId = jwtProvider.getUserFromJwt(refreshToken);
         val token = tokenFinder.findById(memberId);
@@ -70,8 +67,8 @@ public class AuthService {
         return memberFinder.findByEmail(request.email()).orElseThrow(() -> new MemberException(INVALID_MEMBER));
     }
 
-    private void checkTokenEmpty(String token){
-        if(StringUtils.isEmpty(token)){
+    private void checkTokenEmpty(String token) {
+        if (StringUtils.isEmpty(token)) {
             throw new AuthException(EMPTY_JWT);
         }
     }

--- a/src/main/java/com/tiki/server/common/handler/ErrorHandler.java
+++ b/src/main/java/com/tiki/server/common/handler/ErrorHandler.java
@@ -24,67 +24,66 @@ import static com.tiki.server.auth.message.ErrorCode.UNCAUGHT_SERVER_EXCEPTION;
 @RestControllerAdvice
 public class ErrorHandler {
 
-	@ExceptionHandler(MemberException.class)
-	public ResponseEntity<BaseResponse> memberException(MemberException exception) {
-		log.error(exception.getMessage());
-		val errorCode = exception.getErrorCode();
-		return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
-	}
+    @ExceptionHandler(MemberException.class)
+    public ResponseEntity<BaseResponse> memberException(MemberException exception) {
+        log.error(exception.getMessage());
+        val errorCode = exception.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
+    }
 
-	@ExceptionHandler(TeamException.class)
-	public ResponseEntity<BaseResponse> teamException(TeamException exception) {
-		log.error(exception.getMessage());
-		val errorCode = exception.getErrorCode();
-		return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
-	}
+    @ExceptionHandler(TeamException.class)
+    public ResponseEntity<BaseResponse> teamException(TeamException exception) {
+        log.error(exception.getMessage());
+        val errorCode = exception.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
+    }
 
-	@ExceptionHandler(MemberTeamManagerException.class)
-	public ResponseEntity<BaseResponse> memberTeamManagerException(MemberTeamManagerException exception) {
-		log.error(exception.getMessage());
-		val errorCode = exception.getErrorCode();
-		return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
-	}
+    @ExceptionHandler(MemberTeamManagerException.class)
+    public ResponseEntity<BaseResponse> memberTeamManagerException(MemberTeamManagerException exception) {
+        log.error(exception.getMessage());
+        val errorCode = exception.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
+    }
 
-	@ExceptionHandler(TimeBlockException.class)
-	public ResponseEntity<BaseResponse> timeBlockException(TimeBlockException exception) {
-		log.error(exception.getMessage());
-		val errorCode = exception.getErrorCode();
-		return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
-	}
+    @ExceptionHandler(TimeBlockException.class)
+    public ResponseEntity<BaseResponse> timeBlockException(TimeBlockException exception) {
+        log.error(exception.getMessage());
+        val errorCode = exception.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
+    }
 
-	@ExceptionHandler(DocumentException.class)
-	public ResponseEntity<BaseResponse> documentException(DocumentException exception) {
-		log.error(exception.getMessage());
-		val errorCode = exception.getErrorCode();
-		return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
-	}
+    @ExceptionHandler(DocumentException.class)
+    public ResponseEntity<BaseResponse> documentException(DocumentException exception) {
+        log.error(exception.getMessage());
+        val errorCode = exception.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
+    }
 
-	@ExceptionHandler(ExternalException.class)
-	public ResponseEntity<BaseResponse> externalException(ExternalException exception) {
-		log.error(exception.getMessage());
-		val errorCode = exception.getErrorCode();
-		return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
-	}
+    @ExceptionHandler(ExternalException.class)
+    public ResponseEntity<BaseResponse> externalException(ExternalException exception) {
+        log.error(exception.getMessage());
+        val errorCode = exception.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
+    }
 
-	@ExceptionHandler(MailException.class)
-	public ResponseEntity<BaseResponse> MailException(MailException exception) {
-		log.error(exception.getMessage());
-		val errorCode = exception.getErrorCode();
-		return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
-	}
+    @ExceptionHandler(MailException.class)
+    public ResponseEntity<BaseResponse> MailException(MailException exception) {
+        log.error(exception.getMessage());
+        val errorCode = exception.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
+    }
 
-	@ExceptionHandler(AuthException.class)
-	public ResponseEntity<BaseResponse> AuthException(AuthException exception) {
-		log.error(exception.getMessage());
-		val errorCode = exception.getErrorCode();
-		return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
-	}
+    @ExceptionHandler(AuthException.class)
+    public ResponseEntity<BaseResponse> AuthException(AuthException exception) {
+        log.error(exception.getMessage());
+        val errorCode = exception.getErrorCode();
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
+    }
 
-	@ExceptionHandler(Exception.class)
-	public ResponseEntity<BaseResponse> Exception(Exception exception) {
-		log.info("here!!");
-		log.error(exception.getMessage());
-		val errorCode = UNCAUGHT_SERVER_EXCEPTION;
-		return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
-	}
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<BaseResponse> Exception(Exception exception) {
+        log.error(exception.getMessage());
+        val errorCode = UNCAUGHT_SERVER_EXCEPTION;
+        return ResponseEntity.status(errorCode.getHttpStatus()).body(ErrorResponse.of(errorCode.getMessage()));
+    }
 }


### PR DESCRIPTION
## ✨ Related Issue
- close #137 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/user-attachments/assets/55ff5dc6-3d21-425d-9b07-ab7e119d9f7b)

## 🐥 추가적인 언급 사항
리이슈 로직시 리프레쉬 토큰을 기존에는 헤더로 받고 있었는데 클라이언트로 전송할 때 쿠키전송으로 바꿨으니 받는것도 쿠키로 변경했습니다.