### PR TITLE
[REFACTOR] 1차 스프린트 리팩토링

### DIFF
--- a/src/main/java/com/tiki/server/common/config/SwaggerConfig.java
+++ b/src/main/java/com/tiki/server/common/config/SwaggerConfig.java
@@ -36,13 +36,15 @@ public class SwaggerConfig {
 		info.setDescription("티키 API 명세서");
 		info.setVersion("1.0.0");
 
-		val server = new Server();
-		server.setUrl("https://www.tiki-sopt.p-e.kr");
+		val localServer = new Server();
+		val devServer = new Server();
+		devServer.setUrl("https://www.tiki-sopt.p-e.kr");
+		localServer.setUrl("http://localhost:8080");
 
 		return new OpenAPI()
 			.components(components)
 			.security(List.of(securityRequirement))
-			.servers(List.of(server))
+			.servers(List.of(localServer, devServer))
 			.info(info);
 	}
 }

--- a/src/main/java/com/tiki/server/common/config/SwaggerConfig.java
+++ b/src/main/java/com/tiki/server/common/config/SwaggerConfig.java
@@ -13,31 +13,30 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
-import lombok.val;
 
 @Configuration
 public class SwaggerConfig {
 
 	@Bean
 	public OpenAPI openApi() {
-		val securityScheme = new SecurityScheme();
+		SecurityScheme securityScheme = new SecurityScheme();
 		securityScheme.setType(HTTP);
 		securityScheme.setScheme("bearer");
 		securityScheme.setBearerFormat("JWT");
 
-		val components = new Components();
+		Components components = new Components();
 		components.addSecuritySchemes("BearerAuthentication", securityScheme);
 
-		val securityRequirement = new SecurityRequirement();
+		SecurityRequirement securityRequirement = new SecurityRequirement();
 		securityRequirement.addList("BearerAuthentication");
 
-		val info = new Info();
+		Info info = new Info();
 		info.setTitle("TIKI API Document");
 		info.setDescription("티키 API 명세서");
 		info.setVersion("1.0.0");
 
-		val localServer = new Server();
-		val devServer = new Server();
+		Server localServer = new Server();
+		Server devServer = new Server();
 		devServer.setUrl("https://www.tiki-sopt.p-e.kr");
 		localServer.setUrl("http://localhost:8080");
 

--- a/src/main/java/com/tiki/server/common/entity/Position.java
+++ b/src/main/java/com/tiki/server/common/entity/Position.java
@@ -1,5 +1,9 @@
 package com.tiki.server.common.entity;
 
+import static com.tiki.server.timeblock.message.ErrorCode.INVALID_TYPE;
+
+import com.tiki.server.timeblock.exception.TimeBlockException;
+
 import lombok.Getter;
 
 @Getter
@@ -10,5 +14,13 @@ public enum Position {
 
 	Position(int authorization) {
 		this.authorization = authorization;
+	}
+
+	public static Position getAccessiblePosition(String type) {
+		return switch (type) {
+			case "executive" -> EXECUTIVE;
+			case "member" -> MEMBER;
+			default -> throw new TimeBlockException(INVALID_TYPE);
+		};
 	}
 }

--- a/src/main/java/com/tiki/server/document/adapter/DocumentDeleter.java
+++ b/src/main/java/com/tiki/server/document/adapter/DocumentDeleter.java
@@ -19,11 +19,11 @@ public class DocumentDeleter {
 		documentRepository.delete(document);
 	}
 
-	public void deleteAllById(List<DocumentVO> documents) {
-		documents.forEach(documentVO -> documentRepository.deleteById(documentVO.documentId()));
-	}
-
 	public void deleteAll(List<Document> documents) {
 		documentRepository.deleteAll(documents);
+	}
+
+	public void deleteAllByTimeBlockId(long timeBlockId) {
+		documentRepository.deleteAllByTimeBlockId(timeBlockId);
 	}
 }

--- a/src/main/java/com/tiki/server/document/adapter/DocumentFinder.java
+++ b/src/main/java/com/tiki/server/document/adapter/DocumentFinder.java
@@ -1,10 +1,14 @@
 package com.tiki.server.document.adapter;
 
+import static com.tiki.server.document.message.ErrorCode.INVALID_DOCUMENT;
+
 import java.util.List;
+import java.util.Objects;
 
 import com.tiki.server.common.entity.Position;
 import com.tiki.server.common.support.RepositoryAdapter;
 import com.tiki.server.document.entity.Document;
+import com.tiki.server.document.exception.DocumentException;
 import com.tiki.server.document.repository.DocumentRepository;
 import com.tiki.server.document.vo.DocumentVO;
 
@@ -17,7 +21,11 @@ public class DocumentFinder {
 	private final DocumentRepository documentRepository;
 
 	public Document findByIdWithTimeBlock(long documentId) {
-		return documentRepository.findByIdWithTimeBlock(documentId);
+		Document document = documentRepository.findByIdWithTimeBlock(documentId);
+		if (Objects.isNull(document)) {
+			throw new DocumentException(INVALID_DOCUMENT);
+		}
+		return document;
 	}
 
 	public List<DocumentVO> findAllByTimeBlockId(long timeBlockId) {

--- a/src/main/java/com/tiki/server/document/adapter/DocumentFinder.java
+++ b/src/main/java/com/tiki/server/document/adapter/DocumentFinder.java
@@ -16,8 +16,8 @@ public class DocumentFinder {
 
 	private final DocumentRepository documentRepository;
 
-	public Document findByIdWithTimeBlock(long id) {
-		return documentRepository.findByIdWithTimeBlock(id);
+	public Document findByIdWithTimeBlock(long documentId) {
+		return documentRepository.findByIdWithTimeBlock(documentId);
 	}
 
 	public List<DocumentVO> findAllByTimeBlockId(long timeBlockId) {

--- a/src/main/java/com/tiki/server/document/repository/DocumentRepository.java
+++ b/src/main/java/com/tiki/server/document/repository/DocumentRepository.java
@@ -20,4 +20,6 @@ public interface DocumentRepository extends JpaRepository<Document, Long> {
 
 	@Query("select d from Document d join fetch d.timeBlock where d.id = :documentId")
 	Document findByIdWithTimeBlock(long documentId);
+
+	void deleteAllByTimeBlockId(long timeBlockId);
 }

--- a/src/main/java/com/tiki/server/document/service/DocumentService.java
+++ b/src/main/java/com/tiki/server/document/service/DocumentService.java
@@ -39,7 +39,6 @@ public class DocumentService {
 	public void deleteDocument(long memberId, long teamId, long documentId) {
 		MemberTeamManager memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
 		Document document = documentFinder.findByIdWithTimeBlock(documentId);
-		checkDocumentExist(document);
 		memberTeamManager.checkMemberAccessible(document.getTimeBlock().getAccessiblePosition());
 		documentDeleter.delete(document);
 	}
@@ -47,11 +46,5 @@ public class DocumentService {
 	private DocumentsGetResponse getAllDocumentsByType(long teamId, Position accessiblePosition) {
 		List<Document> documents = documentFinder.findAllByTeamIdAndAccessiblePosition(teamId, accessiblePosition);
 		return DocumentsGetResponse.from(documents);
-	}
-
-	private void checkDocumentExist(Document document) {
-		if (Objects.isNull(document)) {
-			throw new DocumentException(INVALID_DOCUMENT);
-		}
 	}
 }

--- a/src/main/java/com/tiki/server/document/service/DocumentService.java
+++ b/src/main/java/com/tiki/server/document/service/DocumentService.java
@@ -1,9 +1,6 @@
 package com.tiki.server.document.service;
 
 import static com.tiki.server.document.message.ErrorCode.INVALID_DOCUMENT;
-import static com.tiki.server.document.message.ErrorCode.INVALID_TYPE;
-import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
-import static com.tiki.server.timeblock.constant.TimeBlockConstant.MEMBER;
 
 import java.util.List;
 import java.util.Objects;
@@ -33,7 +30,7 @@ public class DocumentService {
 
 	public DocumentsGetResponse getAllDocuments(long memberId, long teamId, String type) {
 		MemberTeamManager memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
-		Position accessiblePosition = getAccessiblePosition(type);
+		Position accessiblePosition = Position.getAccessiblePosition(type);
 		memberTeamManager.checkMemberAccessible(accessiblePosition);
 		return getAllDocumentsByType(teamId, accessiblePosition);
 	}
@@ -45,14 +42,6 @@ public class DocumentService {
 		checkDocumentExist(document);
 		memberTeamManager.checkMemberAccessible(document.getTimeBlock().getAccessiblePosition());
 		documentDeleter.delete(document);
-	}
-
-	private Position getAccessiblePosition(String type) {
-		return switch (type) {
-			case EXECUTIVE -> Position.EXECUTIVE;
-			case MEMBER -> Position.MEMBER;
-			default -> throw new DocumentException(INVALID_TYPE);
-		};
 	}
 
 	private DocumentsGetResponse getAllDocumentsByType(long teamId, Position accessiblePosition) {

--- a/src/main/java/com/tiki/server/document/service/DocumentService.java
+++ b/src/main/java/com/tiki/server/document/service/DocumentService.java
@@ -1,11 +1,11 @@
 package com.tiki.server.document.service;
 
-import static com.tiki.server.document.message.ErrorCode.INVALID_AUTHORIZATION;
 import static com.tiki.server.document.message.ErrorCode.INVALID_DOCUMENT;
 import static com.tiki.server.document.message.ErrorCode.INVALID_TYPE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.MEMBER;
 
+import java.util.List;
 import java.util.Objects;
 
 import org.springframework.stereotype.Service;
@@ -18,9 +18,9 @@ import com.tiki.server.document.dto.response.DocumentsGetResponse;
 import com.tiki.server.document.entity.Document;
 import com.tiki.server.document.exception.DocumentException;
 import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
+import com.tiki.server.memberteammanager.entity.MemberTeamManager;
 
 import lombok.RequiredArgsConstructor;
-import lombok.val;
 
 @Service
 @RequiredArgsConstructor
@@ -32,42 +32,37 @@ public class DocumentService {
 	private final MemberTeamManagerFinder memberTeamManagerFinder;
 
 	public DocumentsGetResponse getAllDocuments(long memberId, long teamId, String type) {
-		val position = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId).getPosition();
-		return switch (type) {
-			case EXECUTIVE -> getAllDocumentsByType(teamId, Position.EXECUTIVE, position);
-			case MEMBER -> getAllDocumentsByType(teamId, Position.MEMBER, position);
-			default -> throw new DocumentException(INVALID_TYPE);
-		};
+		MemberTeamManager memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
+		Position accessiblePosition = getAccessiblePosition(type);
+		memberTeamManager.checkMemberAccessible(accessiblePosition);
+		return getAllDocumentsByType(teamId, accessiblePosition);
 	}
 
 	@Transactional
 	public void deleteDocument(long memberId, long teamId, long documentId) {
-		val position = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId).getPosition();
-		val document = documentFinder.findByIdWithTimeBlock(documentId);
+		MemberTeamManager memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
+		Document document = documentFinder.findByIdWithTimeBlock(documentId);
 		checkDocumentExist(document);
-		checkMemberAccessible(document.getTimeBlock().getAccessiblePosition(), position);
+		memberTeamManager.checkMemberAccessible(document.getTimeBlock().getAccessiblePosition());
 		documentDeleter.delete(document);
 	}
 
-	private DocumentsGetResponse getAllDocumentsByType(
-		long teamId,
-		Position accessiblePosition,
-		Position memberPosition
-	) {
-		checkMemberAccessible(accessiblePosition, memberPosition);
-		val documents = documentFinder.findAllByTeamIdAndAccessiblePosition(teamId, accessiblePosition);
+	private Position getAccessiblePosition(String type) {
+		return switch (type) {
+			case EXECUTIVE -> Position.EXECUTIVE;
+			case MEMBER -> Position.MEMBER;
+			default -> throw new DocumentException(INVALID_TYPE);
+		};
+	}
+
+	private DocumentsGetResponse getAllDocumentsByType(long teamId, Position accessiblePosition) {
+		List<Document> documents = documentFinder.findAllByTeamIdAndAccessiblePosition(teamId, accessiblePosition);
 		return DocumentsGetResponse.from(documents);
 	}
 
 	private void checkDocumentExist(Document document) {
 		if (Objects.isNull(document)) {
 			throw new DocumentException(INVALID_DOCUMENT);
-		}
-	}
-
-	private void checkMemberAccessible(Position accessiblePosition, Position memberPosition) {
-		if (accessiblePosition.getAuthorization() < memberPosition.getAuthorization()) {
-			throw new DocumentException(INVALID_AUTHORIZATION);
 		}
 	}
 }

--- a/src/main/java/com/tiki/server/external/constant/ExternalConstant.java
+++ b/src/main/java/com/tiki/server/external/constant/ExternalConstant.java
@@ -4,4 +4,5 @@ public class ExternalConstant {
 
 	public static final Long PRE_SIGNED_URL_EXPIRE_MINUTE = 10L;
 	public static final String FILE_SAVE_PREFIX = "file/";
+	public static final String FILE_DELIMITER = ".";
 }

--- a/src/main/java/com/tiki/server/external/controller/S3Controller.java
+++ b/src/main/java/com/tiki/server/external/controller/S3Controller.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.RestController;
 import com.tiki.server.common.dto.BaseResponse;
 import com.tiki.server.common.dto.SuccessResponse;
 import com.tiki.server.external.controller.docs.S3ControllerDocs;
-import com.tiki.server.external.dto.request.PreSignedUrlRequest;
 import com.tiki.server.external.dto.request.S3DeleteRequest;
 import com.tiki.server.external.dto.response.PreSignedUrlResponse;
 import com.tiki.server.external.util.S3Service;

--- a/src/main/java/com/tiki/server/external/util/S3Service.java
+++ b/src/main/java/com/tiki/server/external/util/S3Service.java
@@ -3,7 +3,7 @@ package com.tiki.server.external.util;
 import static com.tiki.server.external.constant.ExternalConstant.FILE_SAVE_PREFIX;
 import static com.tiki.server.external.constant.ExternalConstant.PRE_SIGNED_URL_EXPIRE_MINUTE;
 import static com.tiki.server.external.message.ErrorCode.*;
-import static com.tiki.server.timeblock.constant.TimeBlockConstant.FILE_DELIMITER;
+import static com.tiki.server.external.constant.ExternalConstant.FILE_DELIMITER;
 
 import java.time.Duration;
 import java.util.UUID;
@@ -17,7 +17,6 @@ import com.tiki.server.external.dto.response.PreSignedUrlResponse;
 import com.tiki.server.external.exception.ExternalException;
 
 import lombok.RequiredArgsConstructor;
-import lombok.val;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;

--- a/src/main/java/com/tiki/server/external/util/S3Service.java
+++ b/src/main/java/com/tiki/server/external/util/S3Service.java
@@ -18,8 +18,10 @@ import com.tiki.server.external.exception.ExternalException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.val;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
 
 @Component
@@ -33,12 +35,12 @@ public class S3Service {
 
 	public PreSignedUrlResponse getUploadPreSignedUrl(String fileFormat) {
 		try {
-			val fileName = generateFileName(fileFormat);
-			val key = FILE_SAVE_PREFIX + fileName;
-			val preSigner = awsConfig.getS3PreSigner();
-			val putObjectRequest = createPutObjectRequest(key);
-			val putObjectPresignRequest = createPutObjectPresignRequest(putObjectRequest);
-			val url = preSigner.presignPutObject(putObjectPresignRequest).url().toString();
+			String fileName = generateFileName(fileFormat);
+			String key = FILE_SAVE_PREFIX + fileName;
+			S3Presigner preSigner = awsConfig.getS3PreSigner();
+			PutObjectRequest putObjectRequest = createPutObjectRequest(key);
+			PutObjectPresignRequest putObjectPresignRequest = createPutObjectPresignRequest(putObjectRequest);
+			String url = preSigner.presignPutObject(putObjectPresignRequest).url().toString();
 			return PreSignedUrlResponse.of(fileName, url);
 		} catch (RuntimeException e) {
 			throw new ExternalException(PRESIGNED_URL_GET_ERROR);
@@ -47,7 +49,7 @@ public class S3Service {
 
 	public void deleteFile(S3DeleteRequest request) {
 		try {
-			val s3Client = awsConfig.getS3Client();
+			S3Client s3Client = awsConfig.getS3Client();
 			s3Client.deleteObject((DeleteObjectRequest.Builder builder) ->
 				builder.bucket(bucket)
 					.key(request.fileName())

--- a/src/main/java/com/tiki/server/external/util/S3Service.java
+++ b/src/main/java/com/tiki/server/external/util/S3Service.java
@@ -31,9 +31,6 @@ public class S3Service {
 	@Value("${aws-property.bucket}")
 	private String bucket;
 
-	@Value("${aws-property.s3-url}")
-	private String s3URL;
-
 	public PreSignedUrlResponse getUploadPreSignedUrl(String fileFormat) {
 		try {
 			val fileName = generateFileName(fileFormat);

--- a/src/main/java/com/tiki/server/memberteammanager/entity/MemberTeamManager.java
+++ b/src/main/java/com/tiki/server/memberteammanager/entity/MemberTeamManager.java
@@ -1,5 +1,7 @@
 package com.tiki.server.memberteammanager.entity;
 
+import static com.tiki.server.memberteammanager.message.ErrorCode.*;
+import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -9,6 +11,8 @@ import static lombok.AccessLevel.PROTECTED;
 import com.tiki.server.common.entity.BaseTime;
 import com.tiki.server.common.entity.Position;
 import com.tiki.server.member.entity.Member;
+import com.tiki.server.memberteammanager.exception.MemberTeamManagerException;
+import com.tiki.server.memberteammanager.message.ErrorCode;
 import com.tiki.server.team.entity.Team;
 
 import jakarta.persistence.Column;
@@ -55,5 +59,11 @@ public class MemberTeamManager extends BaseTime {
 			.name(member.getName())
 			.position(position)
 			.build();
+	}
+
+	public void checkMemberAccessible(Position accesiblePosition) {
+		if (this.position.getAuthorization() > accesiblePosition.getAuthorization()) {
+			throw new MemberTeamManagerException(INVALID_AUTHORIZATION);
+		}
 	}
 }

--- a/src/main/java/com/tiki/server/memberteammanager/entity/MemberTeamManager.java
+++ b/src/main/java/com/tiki/server/memberteammanager/entity/MemberTeamManager.java
@@ -1,7 +1,6 @@
 package com.tiki.server.memberteammanager.entity;
 
 import static com.tiki.server.memberteammanager.message.ErrorCode.*;
-import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
 import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -12,7 +11,6 @@ import com.tiki.server.common.entity.BaseTime;
 import com.tiki.server.common.entity.Position;
 import com.tiki.server.member.entity.Member;
 import com.tiki.server.memberteammanager.exception.MemberTeamManagerException;
-import com.tiki.server.memberteammanager.message.ErrorCode;
 import com.tiki.server.team.entity.Team;
 
 import jakarta.persistence.Column;

--- a/src/main/java/com/tiki/server/memberteammanager/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/memberteammanager/message/ErrorCode.java
@@ -1,5 +1,6 @@
 package com.tiki.server.memberteammanager.message;
 
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import org.springframework.http.HttpStatus;
@@ -10,6 +11,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+
+	/* 403 FORBIDDEN : 권한 없음 */
+	INVALID_AUTHORIZATION(FORBIDDEN, "권한이 없습니다."),
 
 	/* 404 NOT_FOUND : 자원을 찾을 수 없음 */
 	INVALID_MEMBER_TEAM_MANAGER(NOT_FOUND, "팀에 존재하지 않는 회원입니다.");

--- a/src/main/java/com/tiki/server/team/controller/TeamController.java
+++ b/src/main/java/com/tiki/server/team/controller/TeamController.java
@@ -46,7 +46,7 @@ public class TeamController implements TeamControllerDocs {
 	@GetMapping
 	public ResponseEntity<SuccessResponse<TeamsGetResponse>> getAllTeams(Principal principal) {
 		val memberId = Long.parseLong(principal.getName());
-		val response = teamService.getAllTeam(memberId);
+		val response = teamService.getAllTeams(memberId);
 		return ResponseEntity.ok().body(success(SUCCESS_GET_TEAMS.getMessage(), response));
 	}
 

--- a/src/main/java/com/tiki/server/team/controller/TeamController.java
+++ b/src/main/java/com/tiki/server/team/controller/TeamController.java
@@ -44,7 +44,7 @@ public class TeamController implements TeamControllerDocs {
 
 	@Override
 	@GetMapping
-	public ResponseEntity<SuccessResponse<TeamsGetResponse>> getAllTeam(Principal principal) {
+	public ResponseEntity<SuccessResponse<TeamsGetResponse>> getAllTeams(Principal principal) {
 		val memberId = Long.parseLong(principal.getName());
 		val response = teamService.getAllTeam(memberId);
 		return ResponseEntity.ok().body(success(SUCCESS_GET_TEAMS.getMessage(), response));

--- a/src/main/java/com/tiki/server/team/controller/TeamController.java
+++ b/src/main/java/com/tiki/server/team/controller/TeamController.java
@@ -8,6 +8,7 @@ import java.security.Principal;
 import com.tiki.server.common.dto.BaseResponse;
 import com.tiki.server.team.dto.response.CategoriesGetResponse;
 import com.tiki.server.team.dto.response.TeamsGetResponse;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,43 +27,43 @@ import lombok.val;
 @RequestMapping("api/v1/teams")
 public class TeamController implements TeamControllerDocs {
 
-    private final TeamService teamService;
+	private final TeamService teamService;
 
-    @Override
-    @PostMapping
-    public ResponseEntity<SuccessResponse<TeamCreateResponse>> createTeam(
-            Principal principal,
-            @RequestBody TeamCreateRequest request
-    ) {
-        val memberId = Long.parseLong(principal.getName());
-        val response = teamService.createTeam(memberId, request);
-        return ResponseEntity.created(
-                UriGenerator.getUri("/api/v1/teams/" + response.teamId())
-        ).body(success(SUCCESS_CREATE_TEAM.getMessage(), response));
-    }
+	@Override
+	@PostMapping
+	public ResponseEntity<SuccessResponse<TeamCreateResponse>> createTeam(
+		Principal principal,
+		@RequestBody TeamCreateRequest request
+	) {
+		val memberId = Long.parseLong(principal.getName());
+		val response = teamService.createTeam(memberId, request);
+		return ResponseEntity.created(
+			UriGenerator.getUri("/api/v1/teams/" + response.teamId())
+		).body(success(SUCCESS_CREATE_TEAM.getMessage(), response));
+	}
 
-    @Override
-    @GetMapping
-    public ResponseEntity<SuccessResponse<TeamsGetResponse>> getAllTeam(Principal principal) {
-        val memberId = Long.parseLong(principal.getName());
-        val response = teamService.getAllTeam(memberId);
-        return ResponseEntity.ok().body(success(SUCCESS_GET_TEAMS.getMessage(), response));
-    }
+	@Override
+	@GetMapping
+	public ResponseEntity<SuccessResponse<TeamsGetResponse>> getAllTeam(Principal principal) {
+		val memberId = Long.parseLong(principal.getName());
+		val response = teamService.getAllTeam(memberId);
+		return ResponseEntity.ok().body(success(SUCCESS_GET_TEAMS.getMessage(), response));
+	}
 
-    @Override
-    @GetMapping("/category")
-    public ResponseEntity<SuccessResponse<CategoriesGetResponse>> getCategories() {
-        val response = teamService.getCategories();
-        return ResponseEntity.ok().body(success(SUCCESS_GET_CATEGORIES.getMessage(), response));
-    }
+	@Override
+	@GetMapping("/category")
+	public ResponseEntity<SuccessResponse<CategoriesGetResponse>> getCategories() {
+		val response = teamService.getCategories();
+		return ResponseEntity.ok().body(success(SUCCESS_GET_CATEGORIES.getMessage(), response));
+	}
 
-    @DeleteMapping("/{teamId}")
-    public ResponseEntity<BaseResponse> deleteTeam(
-        Principal principal,
-        @PathVariable long teamId
-    ) {
-        val memberId = Long.parseLong(principal.getName());
-        teamService.deleteTeam(memberId, teamId);
-        return ResponseEntity.noContent().build();
-    }
+	@DeleteMapping("/{teamId}")
+	public ResponseEntity<BaseResponse> deleteTeam(
+		Principal principal,
+		@PathVariable long teamId
+	) {
+		val memberId = Long.parseLong(principal.getName());
+		teamService.deleteTeam(memberId, teamId);
+		return ResponseEntity.noContent().build();
+	}
 }

--- a/src/main/java/com/tiki/server/team/controller/docs/TeamControllerDocs.java
+++ b/src/main/java/com/tiki/server/team/controller/docs/TeamControllerDocs.java
@@ -67,7 +67,7 @@ public interface TeamControllerDocs {
 				description = "서버 내부 오류",
 				content = @Content(schema = @Schema(implementation = ErrorResponse.class)))}
 	)
-	ResponseEntity<SuccessResponse<TeamsGetResponse>> getAllTeam(
+	ResponseEntity<SuccessResponse<TeamsGetResponse>> getAllTeams(
 		@Parameter(hidden = true) Principal principal
 	);
 

--- a/src/main/java/com/tiki/server/team/dto/request/TeamCreateRequest.java
+++ b/src/main/java/com/tiki/server/team/dto/request/TeamCreateRequest.java
@@ -5,8 +5,8 @@ import com.tiki.server.team.entity.Category;
 import lombok.NonNull;
 
 public record TeamCreateRequest(
-        @NonNull String name,
-        @NonNull Category category,
-        @NonNull String iconImageUrl
+	@NonNull String name,
+	@NonNull Category category,
+	@NonNull String iconImageUrl
 ) {
 }

--- a/src/main/java/com/tiki/server/team/dto/response/TeamCreateResponse.java
+++ b/src/main/java/com/tiki/server/team/dto/response/TeamCreateResponse.java
@@ -8,12 +8,12 @@ import lombok.Builder;
 
 @Builder(access = PRIVATE)
 public record TeamCreateResponse(
-        long teamId
+	long teamId
 ) {
 
-    public static TeamCreateResponse from(Team team) {
-        return TeamCreateResponse.builder()
-                .teamId(team.getId())
-                .build();
-    }
+	public static TeamCreateResponse from(Team team) {
+		return TeamCreateResponse.builder()
+			.teamId(team.getId())
+			.build();
+	}
 }

--- a/src/main/java/com/tiki/server/team/service/TeamService.java
+++ b/src/main/java/com/tiki/server/team/service/TeamService.java
@@ -59,7 +59,7 @@ public class TeamService {
 		return TeamCreateResponse.from(team);
 	}
 
-	public TeamsGetResponse getAllTeam(long memberId) {
+	public TeamsGetResponse getAllTeams(long memberId) {
 		val member = memberFinder.findById(memberId);
 		val univ = member.getUniv();
 		val team = teamFinder.findAllByUniv(univ);

--- a/src/main/java/com/tiki/server/timeblock/constant/TimeBlockConstant.java
+++ b/src/main/java/com/tiki/server/timeblock/constant/TimeBlockConstant.java
@@ -1,8 +1,0 @@
-package com.tiki.server.timeblock.constant;
-
-public class TimeBlockConstant {
-
-	public static final String EXECUTIVE = "executive";
-	public static final String MEMBER = "member";
-	public static final String FILE_DELIMITER = ".";
-}

--- a/src/main/java/com/tiki/server/timeblock/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/timeblock/message/ErrorCode.java
@@ -16,9 +16,6 @@ public enum ErrorCode {
 	/* 400 BAD_REQUEST : 잘못된 요청 */
 	INVALID_TYPE(BAD_REQUEST, "유효한 타입이 아닙니다."),
 
-	/* 403 FORBIDDEN : 권한 없음 */
-	INVALID_AUTHORIZATION(FORBIDDEN, "타임블록에 대한 권한이 없습니다."),
-
 	/* 404 NOT_FOUND : 자원을 찾을 수 없음 */
 	INVALID_TIME_BLOCK(NOT_FOUND, "유효하지 않은 타임 블록입니다.");
 

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -1,6 +1,5 @@
 package com.tiki.server.timeblock.service;
 
-import static com.tiki.server.timeblock.message.ErrorCode.INVALID_AUTHORIZATION;
 import static com.tiki.server.timeblock.message.ErrorCode.INVALID_TYPE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
 import static com.tiki.server.timeblock.constant.TimeBlockConstant.MEMBER;
@@ -53,86 +52,55 @@ public class TimeBlockService {
 		TimeBlockCreateRequest request
 	) {
 		val team = teamFinder.findById(teamId);
-		val position = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId).getPosition();
-		return switch (type) {
-			case EXECUTIVE -> createTimeBlockByType(team, Position.EXECUTIVE, position, request);
-			case MEMBER -> createTimeBlockByType(team, Position.MEMBER, position, request);
-			default -> throw new TimeBlockException(INVALID_TYPE);
-		};
+		val memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
+		val accessiblePosition = getAccessiblePosition(type);
+		memberTeamManager.checkMemberAccessible(accessiblePosition);
+		val timeBlock = saveTimeBlock(team, accessiblePosition, request);
+		saveDocuments(request.files(), timeBlock);
+		return TimeBlockCreateResponse.of(timeBlock.getId());
 	}
 
 	public TimelineGetResponse getTimeline(long memberId, long teamId, String type, String date) {
 		val team = teamFinder.findById(teamId);
-		val position = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId).getPosition();
-		return switch (type) {
-			case EXECUTIVE -> getTimelineByType(team, Position.EXECUTIVE, position, date);
-			case MEMBER -> getTimelineByType(team, Position.MEMBER, position, date);
-			default -> throw new TimeBlockException(INVALID_TYPE);
-		};
+		val memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
+		val accessiblePosition = getAccessiblePosition(type);
+		memberTeamManager.checkMemberAccessible(accessiblePosition);
+		val timeBlocks = timeBlockFinder.findByTeamAndAccessiblePositionAndDate(
+			team.getId(), accessiblePosition.name(), date);
+		return TimelineGetResponse.from(timeBlocks);
 	}
 
 	public TimeBlockDetailGetResponse getTimeBlockDetail(long memberId, long teamId, long timeBlockId) {
-		val position = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId).getPosition();
+		val memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
 		val timeBlock = timeBlockFinder.findById(timeBlockId);
-		checkMemberAccessible(timeBlock.accessiblePosition(), position);
+		memberTeamManager.checkMemberAccessible(timeBlock.accessiblePosition());
 		val documents = documentFinder.findAllByTimeBlockId(timeBlockId);
 		return TimeBlockDetailGetResponse.from(documents);
 	}
 
 	@Transactional
 	public void deleteTimeBlock(long memberId, long teamId, long timeBlockId) {
-		val position = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId).getPosition();
+		val memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
 		val timeBlock = timeBlockFinder.findById(timeBlockId);
-		checkMemberAccessible(timeBlock.accessiblePosition(), position);
+		memberTeamManager.checkMemberAccessible(timeBlock.accessiblePosition());
 		val documents = documentFinder.findAllByTimeBlockId(timeBlockId);
 		documentDeleter.deleteAllById(documents);
 		timeBlockDeleter.deleteById(timeBlock.timeBlockId());
 	}
 
-	private TimeBlockCreateResponse createTimeBlockByType(
-		Team team,
-		Position accessiblePosition,
-		Position memberPosition,
-		TimeBlockCreateRequest request
-	) {
-		checkMemberAccessible(accessiblePosition, memberPosition);
-		val timeBlock = saveTimeBlock(team, accessiblePosition, request);
-		val timeBlockId = timeBlock.getId();
-		saveDocuments(request.files(), timeBlock);
-		return TimeBlockCreateResponse.of(timeBlockId);
+	private Position getAccessiblePosition(String type) {
+		return switch (type) {
+			case EXECUTIVE -> Position.EXECUTIVE;
+			case MEMBER -> Position.MEMBER;
+			default -> throw new TimeBlockException(INVALID_TYPE);
+		};
 	}
 
 	private TimeBlock saveTimeBlock(Team team, Position accessiblePosition, TimeBlockCreateRequest request) {
-		return timeBlockSaver.save(createTimeBlock(team, accessiblePosition, request));
-	}
-
-	private TimeBlock createTimeBlock(Team team, Position accessiblePosition, TimeBlockCreateRequest request) {
-		return TimeBlock.of(team, accessiblePosition, request);
+		return timeBlockSaver.save(TimeBlock.of(team, accessiblePosition, request));
 	}
 
 	private void saveDocuments(Map<String, String> files, TimeBlock timeBlock) {
-		files.forEach((fileName, fileUrl) -> documentSaver.save(createDocument(fileName, fileUrl, timeBlock)));
-	}
-
-	private Document createDocument(String fileName, String fileUrl, TimeBlock timeBlock) {
-		return Document.of(fileName, fileUrl, timeBlock);
-	}
-
-	private TimelineGetResponse getTimelineByType(
-		Team team,
-		Position accessiblePosition,
-		Position memberPosition,
-		String date
-	) {
-		checkMemberAccessible(accessiblePosition, memberPosition);
-		val timeBlocks = timeBlockFinder.findByTeamAndAccessiblePositionAndDate(
-			team.getId(), accessiblePosition.name(), date);
-		return TimelineGetResponse.from(timeBlocks);
-	}
-
-	private void checkMemberAccessible(Position accessiblePosition, Position memberPosition) {
-		if (accessiblePosition.getAuthorization() < memberPosition.getAuthorization()) {
-			throw new TimeBlockException(INVALID_AUTHORIZATION);
-		}
+		files.forEach((fileName, fileUrl) -> documentSaver.save(Document.of(fileName, fileUrl, timeBlock)));
 	}
 }

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -1,9 +1,5 @@
 package com.tiki.server.timeblock.service;
 
-import static com.tiki.server.timeblock.message.ErrorCode.INVALID_TYPE;
-import static com.tiki.server.timeblock.constant.TimeBlockConstant.EXECUTIVE;
-import static com.tiki.server.timeblock.constant.TimeBlockConstant.MEMBER;
-
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +53,7 @@ public class TimeBlockService {
 	) {
 		Team team = teamFinder.findById(teamId);
 		MemberTeamManager memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
-		Position accessiblePosition = getAccessiblePosition(type);
+		Position accessiblePosition = Position.getAccessiblePosition(type);
 		memberTeamManager.checkMemberAccessible(accessiblePosition);
 		TimeBlock timeBlock = saveTimeBlock(team, accessiblePosition, request);
 		saveDocuments(request.files(), timeBlock);
@@ -67,7 +63,7 @@ public class TimeBlockService {
 	public TimelineGetResponse getTimeline(long memberId, long teamId, String type, String date) {
 		Team team = teamFinder.findById(teamId);
 		MemberTeamManager memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
-		Position accessiblePosition = getAccessiblePosition(type);
+		Position accessiblePosition = Position.getAccessiblePosition(type);
 		memberTeamManager.checkMemberAccessible(accessiblePosition);
 		List<TimeBlockVO> timeBlocks = timeBlockFinder.findByTeamAndAccessiblePositionAndDate(
 			team.getId(), accessiblePosition.name(), date);
@@ -89,14 +85,6 @@ public class TimeBlockService {
 		memberTeamManager.checkMemberAccessible(timeBlock.accessiblePosition());
 		documentDeleter.deleteAllByTimeBlockId(timeBlock.timeBlockId());
 		timeBlockDeleter.deleteById(timeBlock.timeBlockId());
-	}
-
-	private Position getAccessiblePosition(String type) {
-		return switch (type) {
-			case EXECUTIVE -> Position.EXECUTIVE;
-			case MEMBER -> Position.MEMBER;
-			default -> throw new TimeBlockException(INVALID_TYPE);
-		};
 	}
 
 	private TimeBlock saveTimeBlock(Team team, Position accessiblePosition, TimeBlockCreateRequest request) {

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -87,8 +87,7 @@ public class TimeBlockService {
 		MemberTeamManager memberTeamManager = memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
 		TimeBlockVO timeBlock = timeBlockFinder.findById(timeBlockId);
 		memberTeamManager.checkMemberAccessible(timeBlock.accessiblePosition());
-		List<DocumentVO> documents = documentFinder.findAllByTimeBlockId(timeBlockId);
-		documentDeleter.deleteAllById(documents);
+		documentDeleter.deleteAllByTimeBlockId(timeBlock.timeBlockId());
 		timeBlockDeleter.deleteById(timeBlock.timeBlockId());
 	}
 


### PR DESCRIPTION
## ✨ Related Issue
- close #145 
  <br/>

## 📝 기능 구현 명세
- 모든 api 테스트 완료

## 🐥 추가적인 언급 사항
- val을 제거하여 타입 추론을 지양하였습니다. 
-> 일부는 val을 사용해도 된다고 판단했으나 통일성을 위해 전부 val을 제거하였습니다.
- 기존에는 권한 책임을 DocumentService, TimeBlockService에서 각각 해주었으나 MemberTeamManager로 이를 위임하여 객체지향적 설계를 고려하고자 노력했습니다.
-> 코드가 더욱 깔끔해짐.
- https 배포로 인해 스웨거가 로컬에서 돌아가지 않는 버그를 수정하였습니다. (로컬에서 스웨거를 사용할 때 http://localhost:8080을 선택하시면 됩니다.)