### PR TITLE
[FEAT] 폴더 생성 api

### DIFF
--- a/src/main/java/com/tiki/server/folder/adapter/FolderFinder.java
+++ b/src/main/java/com/tiki/server/folder/adapter/FolderFinder.java
@@ -1,6 +1,10 @@
 package com.tiki.server.folder.adapter;
 
+import static com.tiki.server.folder.message.ErrorCode.INVALID_FOLDER;
+
 import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.folder.entity.Folder;
+import com.tiki.server.folder.exception.FolderException;
 import com.tiki.server.folder.repository.FolderRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -10,4 +14,9 @@ import lombok.RequiredArgsConstructor;
 public class FolderFinder {
 
 	private final FolderRepository folderRepository;
+
+	public Folder findById(long id) {
+		return folderRepository.findById(id)
+			.orElseThrow(() -> new FolderException(INVALID_FOLDER));
+	}
 }

--- a/src/main/java/com/tiki/server/folder/adapter/FolderFinder.java
+++ b/src/main/java/com/tiki/server/folder/adapter/FolderFinder.java
@@ -1,0 +1,13 @@
+package com.tiki.server.folder.adapter;
+
+import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.folder.repository.FolderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RepositoryAdapter
+@RequiredArgsConstructor
+public class FolderFinder {
+
+	private final FolderRepository folderRepository;
+}

--- a/src/main/java/com/tiki/server/folder/adapter/FolderSaver.java
+++ b/src/main/java/com/tiki/server/folder/adapter/FolderSaver.java
@@ -1,6 +1,7 @@
 package com.tiki.server.folder.adapter;
 
 import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.folder.entity.Folder;
 import com.tiki.server.folder.repository.FolderRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -10,4 +11,8 @@ import lombok.RequiredArgsConstructor;
 public class FolderSaver {
 
 	private final FolderRepository folderRepository;
+
+	public Folder save(Folder folder) {
+		return folderRepository.save(folder);
+	}
 }

--- a/src/main/java/com/tiki/server/folder/adapter/FolderSaver.java
+++ b/src/main/java/com/tiki/server/folder/adapter/FolderSaver.java
@@ -1,0 +1,13 @@
+package com.tiki.server.folder.adapter;
+
+import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.folder.repository.FolderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RepositoryAdapter
+@RequiredArgsConstructor
+public class FolderSaver {
+
+	private final FolderRepository folderRepository;
+}

--- a/src/main/java/com/tiki/server/folder/controller/FolderController.java
+++ b/src/main/java/com/tiki/server/folder/controller/FolderController.java
@@ -1,0 +1,20 @@
+package com.tiki.server.folder.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.tiki.server.folder.service.FolderService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v2/folders")
+public class FolderController {
+
+	private final FolderService folderService;
+
+	/*
+	폴더 생성하기
+	 */
+}

--- a/src/main/java/com/tiki/server/folder/controller/FolderController.java
+++ b/src/main/java/com/tiki/server/folder/controller/FolderController.java
@@ -1,8 +1,21 @@
 package com.tiki.server.folder.controller;
 
+import static com.tiki.server.common.dto.SuccessResponse.*;
+import static com.tiki.server.folder.message.SuccessMessage.SUCCESS_CREATE_FOLDER;
+
+import java.security.Principal;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.tiki.server.common.dto.SuccessResponse;
+import com.tiki.server.common.support.UriGenerator;
+import com.tiki.server.folder.dto.request.FolderCreateRequest;
+import com.tiki.server.folder.dto.response.FolderCreateResponse;
 import com.tiki.server.folder.service.FolderService;
 
 import lombok.RequiredArgsConstructor;
@@ -14,7 +27,15 @@ public class FolderController {
 
 	private final FolderService folderService;
 
-	/*
-	폴더 생성하기
-	 */
+	@PostMapping()
+	public ResponseEntity<SuccessResponse<FolderCreateResponse>> createFolder(
+		Principal principal,
+		@RequestHeader("team-id") long teamId,
+		@RequestBody FolderCreateRequest request
+	) {
+		long memberId = Long.parseLong(principal.getName());
+		FolderCreateResponse response = folderService.create(memberId, teamId, request);
+		return ResponseEntity.created(UriGenerator.getUri("api/v2/folders/" + response.folderId()))
+			.body(success(SUCCESS_CREATE_FOLDER.getMessage(), response));
+	}
 }

--- a/src/main/java/com/tiki/server/folder/dto/request/FolderCreateRequest.java
+++ b/src/main/java/com/tiki/server/folder/dto/request/FolderCreateRequest.java
@@ -1,0 +1,9 @@
+package com.tiki.server.folder.dto.request;
+
+import lombok.NonNull;
+
+public record FolderCreateRequest(
+	@NonNull String name,
+	Long parentId
+) {
+}

--- a/src/main/java/com/tiki/server/folder/dto/response/FolderCreateResponse.java
+++ b/src/main/java/com/tiki/server/folder/dto/response/FolderCreateResponse.java
@@ -1,0 +1,17 @@
+package com.tiki.server.folder.dto.response;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import lombok.Builder;
+
+@Builder(access = PRIVATE)
+public record FolderCreateResponse(
+	long folderId
+) {
+
+	public static FolderCreateResponse from(long folderId) {
+		return FolderCreateResponse.builder()
+			.folderId(folderId)
+			.build();
+	}
+}

--- a/src/main/java/com/tiki/server/folder/exception/FolderException.java
+++ b/src/main/java/com/tiki/server/folder/exception/FolderException.java
@@ -1,0 +1,16 @@
+package com.tiki.server.folder.exception;
+
+import com.tiki.server.folder.message.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class FolderException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public FolderException(ErrorCode errorCode) {
+		super("[FolderException] : " + errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/tiki/server/folder/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/folder/message/ErrorCode.java
@@ -1,9 +1,19 @@
 package com.tiki.server.folder.message;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorCode {
+
+	/* 404 NOT_FOUND : 자원을 찾을 수 없음 */
+	INVALID_FOLDER(NOT_FOUND, "유효하지 않은 폴더입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
 }

--- a/src/main/java/com/tiki/server/folder/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/folder/message/ErrorCode.java
@@ -1,0 +1,9 @@
+package com.tiki.server.folder.message;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+}

--- a/src/main/java/com/tiki/server/folder/message/SuccessMessage.java
+++ b/src/main/java/com/tiki/server/folder/message/SuccessMessage.java
@@ -1,0 +1,9 @@
+package com.tiki.server.folder.message;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SuccessMessage {
+}

--- a/src/main/java/com/tiki/server/folder/message/SuccessMessage.java
+++ b/src/main/java/com/tiki/server/folder/message/SuccessMessage.java
@@ -6,4 +6,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SuccessMessage {
+
+	SUCCESS_CREATE_FOLDER("폴더 생성 성공");
+
+	private final String message;
 }

--- a/src/main/java/com/tiki/server/folder/repository/FolderRepository.java
+++ b/src/main/java/com/tiki/server/folder/repository/FolderRepository.java
@@ -1,0 +1,8 @@
+package com.tiki.server.folder.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.tiki.server.folder.entity.Folder;
+
+public interface FolderRepository extends JpaRepository<Folder, Long> {
+}

--- a/src/main/java/com/tiki/server/folder/service/FolderService.java
+++ b/src/main/java/com/tiki/server/folder/service/FolderService.java
@@ -3,7 +3,12 @@ package com.tiki.server.folder.service;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.tiki.server.folder.repository.FolderRepository;
+import com.tiki.server.folder.adapter.FolderFinder;
+import com.tiki.server.folder.adapter.FolderSaver;
+import com.tiki.server.folder.dto.request.FolderCreateRequest;
+import com.tiki.server.folder.dto.response.FolderCreateResponse;
+import com.tiki.server.folder.entity.Folder;
+import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
 
 import lombok.RequiredArgsConstructor;
 
@@ -12,6 +17,23 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class FolderService {
 
-	private final FolderRepository folderRepository;
+	private final FolderFinder folderFinder;
+	private final FolderSaver folderSaver;
+	private final MemberTeamManagerFinder memberTeamManagerFinder;
 
+	@Transactional
+	public FolderCreateResponse create(long memberId, long teamId, FolderCreateRequest request) {
+		// 같은 레벨 파일명 중복 방지 로직 추가 필요
+		memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
+		Folder parentFolder = getFolder(request.parentId());
+		Folder folder = folderSaver.save(new Folder(request.name(), parentFolder, teamId));
+		return FolderCreateResponse.from(folder.getId());
+	}
+
+	private Folder getFolder(Long folderId) {
+		if (folderId == null) {
+			return null;
+		}
+		return folderFinder.findById(folderId);
+	}
 }

--- a/src/main/java/com/tiki/server/folder/service/FolderService.java
+++ b/src/main/java/com/tiki/server/folder/service/FolderService.java
@@ -1,0 +1,17 @@
+package com.tiki.server.folder.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.tiki.server.folder.repository.FolderRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FolderService {
+
+	private final FolderRepository folderRepository;
+
+}


### PR DESCRIPTION
## ✨ Related Issue
- close #153 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/user-attachments/assets/3d2d61bc-81bc-4ee5-93de-89ec0cd80cff)

폴더1
-- 폴더2
----폴더3
--폴더4

- 위치가 루트인 폴더의 path == ""
- 루트에 위치해있는 아이디가 1인 폴더의 자식 폴더의 path == "/1"

## 🐥 추가적인 언급 사항
- 스웨거는 폴더 관련 api를 모두 작성한 뒤 작업하거나 도중에 이슈 파서 작업하겠습니다.
- teamId를 계속해서 PathVariable로 받으니 url이 길어져서 헤더로 받는 방식으로 작업해보았습니다. 클라이언트와 얘기 후, 변동이  생긴다면 수정하겠습니다.
- 201을 반환하다보니 응답 body와 URI에 생성된 폴더 ID를 중복해서 제공해주는데 이 또한 클라이언트와 얘기한 후, 한 쪽으로만 주는 것이 좋을 거 같습니다. -> 기존 API도 수정해야 함.
- 폴더 생성 api의 대략적인 동작 방식은 다음과 같습니다.

1. 클라이언트로부터 부모 폴더 아이디를 받음. (null 가능)
2. null이라면 루트에 위치한 폴더 생성
3. null이 아니라면 받은 부모 폴더 아이디를 토대로 path 생성

- null을 활용한다는 점이 좀 불안정한 거 같기도 한데 구현해야 할 api가 너무 많고 개인적인 다른 일도 쌓여있다보니 일단 추후에 더 좋은 방법이 떠오른다면 리팩토링하는 방식으로 가볼까 하는데 의견 남겨주시면 감사하겠습니다.