### PR TITLE
[FEAT] 삭제 api 수정

### DIFF
--- a/src/main/java/com/tiki/server/auth/controller/AuthController.java
+++ b/src/main/java/com/tiki/server/auth/controller/AuthController.java
@@ -45,12 +45,4 @@ public class AuthController implements AuthControllerDocs {
         ReissueGetResponse response = authService.reissueToken(httpServletRequest);
         return SuccessResponse.success(SUCCESS_REISSUE_ACCESS_TOKEN.getMessage(), response);
     }
-
-    @ResponseStatus(HttpStatus.OK)
-    @GetMapping("/withdrawal")
-    public SuccessResponse<?> withdrawal(final Principal principal) {
-        long memberId = Long.parseLong(principal.getName());
-        authService.withdrawal(memberId);
-        return SuccessResponse.success(SUCCESS_REISSUE_ACCESS_TOKEN.getMessage());
-    }
 }

--- a/src/main/java/com/tiki/server/auth/controller/AuthController.java
+++ b/src/main/java/com/tiki/server/auth/controller/AuthController.java
@@ -21,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 
 import static com.tiki.server.auth.message.SuccessMessage.*;
 
+import java.security.Principal;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/auth")
@@ -42,5 +44,13 @@ public class AuthController implements AuthControllerDocs {
     public SuccessResponse<ReissueGetResponse> reissue(final HttpServletRequest httpServletRequest) {
         ReissueGetResponse response = authService.reissueToken(httpServletRequest);
         return SuccessResponse.success(SUCCESS_REISSUE_ACCESS_TOKEN.getMessage(), response);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/withdrawal")
+    public SuccessResponse<?> withdrawal(final Principal principal) {
+        long memberId = Long.parseLong(principal.getName());
+        authService.withdrawal(memberId);
+        return SuccessResponse.success(SUCCESS_REISSUE_ACCESS_TOKEN.getMessage());
     }
 }

--- a/src/main/java/com/tiki/server/auth/service/AuthService.java
+++ b/src/main/java/com/tiki/server/auth/service/AuthService.java
@@ -44,7 +44,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     public SignInGetResponse signIn(final SignInRequest request) {
-        Member member = checkMemberEmpty(request);
+        Member member = checkMemberEmpty(request.email());
         checkPasswordMatching(member, request.password());
         Authentication authentication = createAuthentication(member.getId());
         String accessToken = jwtGenerator.generateAccessToken(authentication);
@@ -64,8 +64,8 @@ public class AuthService {
         return ReissueGetResponse.from(accessToken);
     }
 
-    private Member checkMemberEmpty(final SignInRequest request) {
-        return memberFinder.findByEmail(Email.from(request.email()))
+    private Member checkMemberEmpty(final String email) {
+        return memberFinder.findByEmail(Email.from(email))
             .orElseThrow(() -> new MemberException(INVALID_MEMBER));
     }
 

--- a/src/main/java/com/tiki/server/auth/service/AuthService.java
+++ b/src/main/java/com/tiki/server/auth/service/AuthService.java
@@ -9,7 +9,6 @@ import com.tiki.server.auth.token.adapter.TokenFinder;
 import com.tiki.server.auth.token.adapter.TokenSaver;
 import com.tiki.server.auth.token.entity.Token;
 import com.tiki.server.email.Email;
-import com.tiki.server.member.adapter.MemberDeleter;
 import com.tiki.server.member.adapter.MemberFinder;
 import com.tiki.server.member.entity.Member;
 import com.tiki.server.member.exception.MemberException;
@@ -22,13 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.tiki.server.auth.jwt.JwtGenerator;
 import com.tiki.server.auth.jwt.UserAuthentication;
-import com.tiki.server.memberteammanager.adapter.MemberTeamManagerDeleter;
-import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
-import com.tiki.server.memberteammanager.entity.MemberTeamManager;
-import com.tiki.server.note.adapter.NoteFinder;
-import com.tiki.server.note.entity.Note;
-import com.tiki.server.team.adapter.TeamFinder;
-import com.tiki.server.team.entity.Team;
 
 import lombok.RequiredArgsConstructor;
 import org.thymeleaf.util.StringUtils;
@@ -37,8 +29,6 @@ import static com.tiki.server.auth.message.ErrorCode.EMPTY_JWT;
 import static com.tiki.server.auth.message.ErrorCode.UNMATCHED_TOKEN;
 import static com.tiki.server.member.message.ErrorCode.INVALID_MEMBER;
 import static com.tiki.server.member.message.ErrorCode.UNMATCHED_PASSWORD;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -49,14 +39,9 @@ public class AuthService {
     private final JwtGenerator jwtGenerator;
     private final JwtProvider jwtProvider;
     private final MemberFinder memberFinder;
-    private final MemberTeamManagerFinder memberTeamManagerFinder;
-    private final MemberTeamManagerDeleter memberTeamManagerDeleter;
-    private final TeamFinder teamFinder;
-    private final NoteFinder noteFinder;
     private final TokenSaver tokenSaver;
     private final TokenFinder tokenFinder;
     private final PasswordEncoder passwordEncoder;
-    private final MemberDeleter memberDeleter;
 
     public SignInGetResponse signIn(final SignInRequest request) {
         Member member = checkMemberEmpty(request);
@@ -77,19 +62,6 @@ public class AuthService {
         Authentication authentication = createAuthentication(memberId);
         String accessToken = jwtGenerator.generateAccessToken(authentication);
         return ReissueGetResponse.from(accessToken);
-    }
-
-    @Transactional
-    public void withdrawal(final long memberId) {
-        Member member = memberFinder.findById(memberId);
-        List<MemberTeamManager> memberTeamManagers = memberTeamManagerFinder.findAllByMemberIdOrderByCreatedAt(memberId);
-        for (MemberTeamManager memberTeamManager : memberTeamManagers) {
-            Team team = teamFinder.findById(memberTeamManager.getTeamId());
-            List<Note> notes = noteFinder.findAllByMemberIdAndTeamId(memberId, team.getId());
-            notes.forEach(Note::deleteMemberDependency);
-            memberTeamManagerDeleter.delete(memberTeamManager);
-        }
-        memberDeleter.delete(member);
     }
 
     private Member checkMemberEmpty(final SignInRequest request) {

--- a/src/main/java/com/tiki/server/common/entity/Position.java
+++ b/src/main/java/com/tiki/server/common/entity/Position.java
@@ -23,4 +23,8 @@ public enum Position {
 			default -> throw new TimeBlockException(INVALID_TYPE);
 		};
 	}
+
+	public static boolean isAdmin(final Position position) {
+		return position == ADMIN;
+	}
 }

--- a/src/main/java/com/tiki/server/document/adapter/DeletedDocumentAdapter.java
+++ b/src/main/java/com/tiki/server/document/adapter/DeletedDocumentAdapter.java
@@ -36,6 +36,10 @@ public class DeletedDocumentAdapter {
 		deletedDocumentRepository.deleteAll(deletedDocuments);
 	}
 
+	public void deleteAllByTeamId(final long teamId) {
+		deletedDocumentRepository.deleteAllByTeamId(teamId);
+	}
+
 	private DeletedDocument create(final Document document) {
 		return DeletedDocument.of(document);
 	}

--- a/src/main/java/com/tiki/server/document/repository/DeletedDocumentRepository.java
+++ b/src/main/java/com/tiki/server/document/repository/DeletedDocumentRepository.java
@@ -12,4 +12,6 @@ public interface DeletedDocumentRepository extends JpaRepository<DeletedDocument
 	Optional<DeletedDocument> findByIdAndTeamId(final long id, final long teamId);
 
 	List<DeletedDocument> findAllByTeamId(final long teamId);
+
+	void deleteAllByTeamId(final long teamId);
 }

--- a/src/main/java/com/tiki/server/document/service/DocumentService.java
+++ b/src/main/java/com/tiki/server/document/service/DocumentService.java
@@ -26,6 +26,7 @@ import com.tiki.server.folder.adapter.FolderFinder;
 import com.tiki.server.folder.entity.Folder;
 import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
 import com.tiki.server.memberteammanager.entity.MemberTeamManager;
+import com.tiki.server.notedocumentmanager.adapter.NDDeleter;
 import com.tiki.server.team.adapter.TeamFinder;
 import com.tiki.server.team.entity.Team;
 
@@ -44,6 +45,7 @@ public class DocumentService {
 	private final DeletedDocumentAdapter deletedDocumentAdapter;
 	private final TeamFinder teamFinder;
 	private final DTBAdapter dtbAdapter;
+	private final NDDeleter ndDeleter;
 	private final AwsHandler awsHandler;
 
 	public DocumentsGetResponse getAllDocuments(final long memberId, final long teamId, final String type) {
@@ -75,6 +77,7 @@ public class DocumentService {
 		memberTeamManagerFinder.findByMemberIdAndTeamId(memberId, teamId);
 		List<Document> documents = documentFinder.findAllByIdAndTeamId(documentIds, teamId);
 		dtbAdapter.deleteAllByDocuments(documentIds);
+		ndDeleter.deleteAllByDocuments(documentIds);
 		deletedDocumentAdapter.save(documents);
 		documentDeleter.deleteAll(documents);
 	}

--- a/src/main/java/com/tiki/server/folder/adapter/FolderDeleter.java
+++ b/src/main/java/com/tiki/server/folder/adapter/FolderDeleter.java
@@ -17,4 +17,8 @@ public class FolderDeleter {
 	public void deleteAll(final List<Folder> folders) {
 		folderRepository.deleteAll(folders);
 	}
+
+	public void deleteAllByTeamId(final long teamId) {
+		folderRepository.deleteAllByTeamId(teamId);
+	}
 }

--- a/src/main/java/com/tiki/server/folder/repository/FolderRepository.java
+++ b/src/main/java/com/tiki/server/folder/repository/FolderRepository.java
@@ -16,4 +16,6 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
 	Optional<Folder> findByIdAndTeamId(final long id, final long teamId);
 
 	List<Folder> findAllByPathStartsWith(final String path);
+
+	void deleteAllByTeamId(final long teamId);
 }

--- a/src/main/java/com/tiki/server/folder/service/FolderService.java
+++ b/src/main/java/com/tiki/server/folder/service/FolderService.java
@@ -22,6 +22,7 @@ import com.tiki.server.folder.dto.response.FoldersGetResponse;
 import com.tiki.server.folder.entity.Folder;
 import com.tiki.server.folder.exception.FolderException;
 import com.tiki.server.memberteammanager.adapter.MemberTeamManagerFinder;
+import com.tiki.server.notedocumentmanager.adapter.NDDeleter;
 
 import lombok.RequiredArgsConstructor;
 
@@ -37,6 +38,7 @@ public class FolderService {
 	private final DocumentDeleter documentDeleter;
 	private final DeletedDocumentAdapter deletedDocumentAdapter;
 	private final FolderDeleter folderDeleter;
+	private final NDDeleter ndDeleter;
 
 	public FoldersGetResponse get(final long memberId, final long teamId,
 			final Long folderId) {
@@ -112,6 +114,7 @@ public class FolderService {
 
 	private void deleteDocuments(final Folder folder) {
 		List<Document> documents = documentFinder.findAllByFolderId(folder.getId());
+		ndDeleter.deleteAllByDocuments(documents.stream().map(Document::getId).toList());
 		deletedDocumentAdapter.save(documents);
 		documentDeleter.deleteAll(documents);
 	}

--- a/src/main/java/com/tiki/server/member/adapter/MemberDeleter.java
+++ b/src/main/java/com/tiki/server/member/adapter/MemberDeleter.java
@@ -1,0 +1,18 @@
+package com.tiki.server.member.adapter;
+
+import com.tiki.server.common.support.RepositoryAdapter;
+import com.tiki.server.member.entity.Member;
+import com.tiki.server.member.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RepositoryAdapter
+@RequiredArgsConstructor
+public class MemberDeleter {
+
+	private final MemberRepository memberRepository;
+
+	public void delete(final Member member) {
+		memberRepository.delete(member);
+	}
+}

--- a/src/main/java/com/tiki/server/member/controller/MemberController.java
+++ b/src/main/java/com/tiki/server/member/controller/MemberController.java
@@ -17,6 +17,7 @@ import java.security.Principal;
 
 import static com.tiki.server.member.message.SuccessMessage.SUCCESS_CHANGING_PASSWORD;
 import static com.tiki.server.member.message.SuccessMessage.SUCCESS_CREATE_MEMBER;
+import static com.tiki.server.member.message.SuccessMessage.SUCCESS_WITHDRAWAL;
 import static com.tiki.server.team.message.SuccessMessage.SUCCESS_GET_JOINED_TEAM;
 
 @RestController
@@ -53,5 +54,13 @@ public class MemberController implements MemberControllerDocs {
     ) {
         memberService.changePassword(passwordChangeRequest);
         return SuccessResponse.success(SUCCESS_CHANGING_PASSWORD.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/withdrawal")
+    public SuccessResponse<?> withdrawal(final Principal principal) {
+        long memberId = Long.parseLong(principal.getName());
+        memberService.withdrawal(memberId);
+        return SuccessResponse.success(SUCCESS_WITHDRAWAL.getMessage());
     }
 }

--- a/src/main/java/com/tiki/server/member/message/SuccessMessage.java
+++ b/src/main/java/com/tiki/server/member/message/SuccessMessage.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum SuccessMessage {
 
     SUCCESS_CREATE_MEMBER("회원가입 성공"),
-    SUCCESS_CHANGING_PASSWORD("비밀번호 변경 성공");
+    SUCCESS_CHANGING_PASSWORD("비밀번호 변경 성공"),
+    SUCCESS_WITHDRAWAL("회원 탈퇴 성공"),;
 
     private final String message;
 }

--- a/src/main/java/com/tiki/server/member/service/MemberService.java
+++ b/src/main/java/com/tiki/server/member/service/MemberService.java
@@ -72,6 +72,7 @@ public class MemberService {
         List<MemberTeamManager> memberTeamManagers = memberTeamManagerFinder.findAllByMemberIdOrderByCreatedAt(memberId);
         for (MemberTeamManager memberTeamManager : memberTeamManagers) {
             Team team = teamFinder.findById(memberTeamManager.getTeamId());
+            memberTeamManager.checkMemberIsNotAdmin();
             List<Note> notes = noteFinder.findAllByMemberIdAndTeamId(memberId, team.getId());
             notes.forEach(Note::deleteMemberDependency);
             memberTeamManagerDeleter.delete(memberTeamManager);

--- a/src/main/java/com/tiki/server/memberteammanager/entity/MemberTeamManager.java
+++ b/src/main/java/com/tiki/server/memberteammanager/entity/MemberTeamManager.java
@@ -62,6 +62,12 @@ public class MemberTeamManager extends BaseTime {
 		}
 	}
 
+	public void checkMemberIsNotAdmin() {
+		if (Position.isAdmin(this.position)) {
+			throw new MemberTeamManagerException(CANNOT_QUIT_TEAM);
+		}
+	}
+
 	public void updateName(final String name){
 		this.name = name;
 	}

--- a/src/main/java/com/tiki/server/memberteammanager/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/memberteammanager/message/ErrorCode.java
@@ -13,7 +13,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-	CONFLICT_TEAM_MEMBER(BAD_REQUEST,"이미 존재하는 팀원입니다"),
+	CONFLICT_TEAM_MEMBER(BAD_REQUEST, "이미 존재하는 팀원입니다"),
+	CANNOT_QUIT_TEAM(BAD_REQUEST, "팀을 탈퇴할 수 없습니다."),
+
 	/* 403 FORBIDDEN : 권한 없음 */
 	INVALID_AUTHORIZATION(FORBIDDEN, "권한이 없습니다."),
 

--- a/src/main/java/com/tiki/server/memberteammanager/message/ErrorCode.java
+++ b/src/main/java/com/tiki/server/memberteammanager/message/ErrorCode.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ErrorCode {
 
-	CONFLICT_TEAM_MEMBER(BAD_REQUEST, "이미 존재하는 팀원입니다"),
+	CONFLICT_TEAM_MEMBER(BAD_REQUEST, "이미 존재하는 팀원입니다."),
 	CANNOT_QUIT_TEAM(BAD_REQUEST, "팀을 탈퇴할 수 없습니다."),
 
 	/* 403 FORBIDDEN : 권한 없음 */

--- a/src/main/java/com/tiki/server/note/adapter/NoteDeleter.java
+++ b/src/main/java/com/tiki/server/note/adapter/NoteDeleter.java
@@ -15,4 +15,8 @@ public class NoteDeleter {
     public void deleteNoteByIds(final List<Long> noteIds){
         noteIds.forEach(noteRepository::deleteById);
     }
+
+    public void deleteAllByTeamId(final long teamId) {
+        noteRepository.deleteAllByTeamId(teamId);
+    }
 }

--- a/src/main/java/com/tiki/server/note/repository/NoteRepository.java
+++ b/src/main/java/com/tiki/server/note/repository/NoteRepository.java
@@ -22,4 +22,6 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
 		final Pageable pageable, final long teamId);
 
 	List<Note> findAllByMemberIdAndTeamId(final long memberId, final long teamId);
+
+	void deleteAllByTeamId(final long teamId);
 }

--- a/src/main/java/com/tiki/server/note/repository/NoteRepository.java
+++ b/src/main/java/com/tiki/server/note/repository/NoteRepository.java
@@ -21,5 +21,5 @@ public interface NoteRepository extends JpaRepository<Note, Long> {
 	List<Note> findByTeamIdAndCreatedAtAfterOrderByCreatedAtAsc(@Param("createdAt") final LocalDateTime createdAt,
 		final Pageable pageable, final long teamId);
 
-	List<Note> findAllByMemberIdAndTeamId(final long memberId, final long TeamId);
+	List<Note> findAllByMemberIdAndTeamId(final long memberId, final long teamId);
 }

--- a/src/main/java/com/tiki/server/notedocumentmanager/adapter/NDDeleter.java
+++ b/src/main/java/com/tiki/server/notedocumentmanager/adapter/NDDeleter.java
@@ -21,4 +21,8 @@ public class NDDeleter {
                 ndRepository.deleteByNoteIdAndDocumentId(noteId, documentId)
         );
     }
+
+    public void deleteAllByDocuments(final List<Long> documentIds) {
+        ndRepository.deleteAllByDocumentIdIn(documentIds);
+    }
 }

--- a/src/main/java/com/tiki/server/notedocumentmanager/repository/NDRepository.java
+++ b/src/main/java/com/tiki/server/notedocumentmanager/repository/NDRepository.java
@@ -12,4 +12,6 @@ public interface NDRepository extends JpaRepository<NDManager, Long> {
     void deleteByNoteIdAndDocumentId(final long noteId, final long documentId);
 
     List<NDManager> findAllByNoteId(final long noteId);
+
+    void deleteAllByDocumentIdIn(final List<Long> documentIds);
 }

--- a/src/main/java/com/tiki/server/notetimeblockmanager/adapter/NTBDeleter.java
+++ b/src/main/java/com/tiki/server/notetimeblockmanager/adapter/NTBDeleter.java
@@ -2,6 +2,8 @@ package com.tiki.server.notetimeblockmanager.adapter;
 
 import com.tiki.server.common.support.RepositoryAdapter;
 import com.tiki.server.notetimeblockmanager.repository.NTBRepository;
+import com.tiki.server.timeblock.entity.TimeBlock;
+
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
@@ -20,5 +22,9 @@ public class NTBDeleter {
         timeBlockIds.forEach(timeBlockId ->
                 ntbRepository.deleteByNoteIdAndTimeBlockId(noteId, timeBlockId)
         );
+    }
+
+    public void deleteAllByTimeBlock(final TimeBlock timeBlock) {
+        ntbRepository.deleteAllByTimeBlockId(timeBlock.getId());
     }
 }

--- a/src/main/java/com/tiki/server/notetimeblockmanager/repository/NTBRepository.java
+++ b/src/main/java/com/tiki/server/notetimeblockmanager/repository/NTBRepository.java
@@ -14,4 +14,6 @@ public interface NTBRepository extends JpaRepository<NTBManager, Long> {
     List<NTBManager> findAllByNoteId(final long noteId);
 
     List<NTBManager> findAllByTimeBlockId(final long timeBlockId);
+
+    void deleteAllByTimeBlockId(final long timeBlockId);
 }

--- a/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
+++ b/src/main/java/com/tiki/server/timeblock/service/TimeBlockService.java
@@ -1,5 +1,6 @@
 package com.tiki.server.timeblock.service;
 
+import com.tiki.server.notetimeblockmanager.adapter.NTBDeleter;
 import com.tiki.server.timeblock.dto.request.TimeBlockUpdateRequest;
 import com.tiki.server.timeblock.service.dto.response.AllTimeBlockServiceResponse;
 import java.util.List;
@@ -47,6 +48,7 @@ public class TimeBlockService {
     private final DTBAdapter dtbAdapter;
     private final NTBFinder ntbFinder;
     private final NoteFinder noteFinder;
+    private final NTBDeleter ntbDeleter;
 
     @Transactional
     public TimeBlockCreateResponse createTimeBlock(
@@ -121,6 +123,7 @@ public class TimeBlockService {
         TimeBlock timeBlock = timeBlockFinder.findByIdAndTeamId(timeBlockId, teamId);
         memberTeamManager.checkMemberAccessible(timeBlock.getAccessiblePosition());
         dtbAdapter.deleteAllByTimeBlock(timeBlock);
+        ntbDeleter.deleteAllByTimeBlock(timeBlock);
         timeBlockDeleter.deleteById(timeBlock.getId());
     }
 


### PR DESCRIPTION
## ✨ Related Issue
- close #243 
  <br/>

## 📝 기능 구현 명세
- 테스트 진행 X

## 🐥 추가적인 언급 사항
- Member와 Auth 간에 api 재분배가 필요할 거 같습니다. 개인적으로 인증/인가 관련 로그인, 회원가입, 토큰 재발급을 Auth로, 이미 생성된 멤버에 대한 로직인 비밀번호 변경, 회원 탈퇴를 Member에 두는 것이 좋은 거 같습니다.
- 테스트 따로 다음주 중에 진행 후, 머지하겠습니다.