### PR TITLE
[FIX] 팀 아이콘 이미지 없을 시 발생하는 버그 수정

### DIFF
--- a/src/main/java/com/tiki/server/external/util/AwsHandler.java
+++ b/src/main/java/com/tiki/server/external/util/AwsHandler.java
@@ -6,6 +6,7 @@ import static com.tiki.server.external.message.ErrorCode.*;
 import static com.tiki.server.external.constant.ExternalConstant.FILE_DELIMITER;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.UUID;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -47,6 +48,9 @@ public class AwsHandler {
 	}
 
 	public String getDownloadPreSignedUrl(final String fileKey) {
+		if (Objects.isNull(fileKey)) {
+			return "";
+		}
 		try {
 			S3Presigner preSigner = awsConfig.getS3PreSigner();
 			GetObjectRequest getObjectRequest = createGetObjectRequest(fileKey);

--- a/src/main/java/com/tiki/server/external/util/AwsHandler.java
+++ b/src/main/java/com/tiki/server/external/util/AwsHandler.java
@@ -62,6 +62,7 @@ public class AwsHandler {
 	}
 
 	public void deleteFile(final String request) {
+		if (request.equals("file/갓슈.png")) return;	// 임시 로직
 		try {
 			S3Client s3Client = awsConfig.getS3Client();
 			s3Client.deleteObject((DeleteObjectRequest.Builder builder) ->


### PR DESCRIPTION
## ✨ Related Issue
- close #275 
  <br/>

## 📝 기능 구현 명세
- 테스트 성공했으나 url 가리기 리소스 부족으로 생략합니다.

## 🐥 추가적인 언급 사항
- 개발 기간 동안 갓슈.png는 삭제되지 않도록 임시 로직 추가하였습니다.
- 현재 awsHandler에서 fileKey가 null일 시, 빈 문자열을 반환하는 로직이 매우 부자연스러우나 개발 기간 이슈로 일단은 이렇게 하고 추후에 이슈 파서 awsHandler 쪽 로직을 수정하도록 하겠습니다.
